### PR TITLE
feat: Sync playable characters from Notion database

### DIFF
--- a/app/api/characters/notion/route.ts
+++ b/app/api/characters/notion/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import { fetchPlayableCharactersFromNotion } from '@/lib/notion';
+
+export async function GET() {
+  try {
+    const characters = await fetchPlayableCharactersFromNotion();
+    return NextResponse.json(characters);
+  } catch (error) {
+    console.error('Failed to fetch characters from Notion:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch characters from Notion' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -17,7 +17,7 @@ interface CampaignInfo {
 }
 
 interface CharacterInfo {
-  id: number;
+  id: string | number;
   name: string;
   class: string;
   level: number;
@@ -87,20 +87,20 @@ function JoinPageContent() {
 
     setIsLoading(true);
     try {
-      // Fetch available characters for this campaign
-      const response = await fetch(`/api/campaigns/${campaignInfo.id}/characters`);
+      // Fetch available characters from Notion
+      const response = await fetch('/api/characters/notion');
       if (response.ok) {
         const data = await response.json();
         setCharacters(data);
         setStep("character");
       } else {
         toast.error("Erreur", {
-          description: "Impossible de charger les personnages",
+          description: "Impossible de charger les personnages depuis Notion",
         });
       }
     } catch (error) {
       console.error("Failed to fetch characters:", error);
-      toast.error("Erreur de connexion");
+      toast.error("Erreur de connexion à Notion");
     } finally {
       setIsLoading(false);
     }

--- a/components/user-selection-screen.tsx
+++ b/components/user-selection-screen.tsx
@@ -17,7 +17,7 @@ import {
 import { cn } from "@/lib/utils"
 
 interface CharacterInfo {
-  id: number
+  id: string | number
   name: string
   class: string
   level: number
@@ -48,21 +48,21 @@ export function UserSelectionScreen({ campaignId, onSelectMJ, onSelectPlayers, d
     async function fetchCharacters() {
       try {
         setLoading(true)
-        const response = await fetch(`/api/campaigns/${campaignId}/characters`)
+        const response = await fetch('/api/characters/notion')
         if (response.ok) {
           const data = await response.json()
           setCharacters(data)
         } else {
-          setError("Impossible de charger les personnages")
+          setError("Impossible de charger les personnages depuis Notion")
         }
       } catch {
-        setError("Erreur de connexion")
+        setError("Erreur de connexion à Notion")
       } finally {
         setLoading(false)
       }
     }
     fetchCharacters()
-  }, [campaignId])
+  }, [])
 
   const getHpColor = (current: number, max: number) => {
     const ratio = current / max

--- a/lib/socket-events.ts
+++ b/lib/socket-events.ts
@@ -4,7 +4,7 @@ export interface JoinCampaignData {
   campaignId: number;
   role: 'dm' | 'player';
   characters?: Array<{
-    odNumber: number;
+    odNumber: string | number; // Notion UUID or legacy DB ID
     name: string;
     class: string;
     level: number;
@@ -22,7 +22,7 @@ export interface ConnectedPlayer {
   socketId: string; // Socket ID
   playerName?: string; // Optional: player's real name
   characters: Array<{
-    odNumber: number; // Character ID from DB
+    odNumber: string | number; // Notion UUID or legacy DB ID
     name: string;
     class: string;
     level: number;

--- a/server.ts
+++ b/server.ts
@@ -17,7 +17,7 @@ interface ConnectedPlayer {
   socketId: string;
   playerName?: string;
   characters: Array<{
-    odNumber: number;
+    odNumber: string | number; // Notion UUID or legacy DB ID
     name: string;
     class: string;
     level: number;
@@ -42,7 +42,7 @@ interface JoinCampaignData {
   role: 'dm' | 'player';
   password?: string; // Required for DM role
   characters?: Array<{
-    odNumber: number;
+    odNumber: string | number; // Notion UUID or legacy DB ID
     name: string;
     class: string;
     level: number;


### PR DESCRIPTION
## Summary
- Fetch playable characters from Notion database instead of PostgreSQL
- Filter by "Joueur" checkbox property in Notion
- Consistent character IDs (Notion UUIDs) across DM and player views
- Session-only character state (HP, conditions reset on page reload)

## Changes
- New API endpoint `/api/characters/notion`
- Extended `lib/notion.ts` with character-fetching functions
- Updated `UserSelectionScreen` and `join/page.tsx` to use Notion endpoint
- Updated `page.tsx` to fetch characters from Notion for both DM and player modes
- Updated socket event types to support string IDs

## Test plan
- [ ] Connect as player and verify characters are fetched from Notion
- [ ] Connect as DM and verify characters appear when players join
- [ ] Apply damage/healing and verify HP updates sync between DM and players
- [ ] Verify conditions and exhaustion sync correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)