### PR TITLE
fix: Update Notion SDK to v5 API with data sources

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,7 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  serverExternalPackages: ['@notionhq/client'],
 }
 
 export default nextConfig


### PR DESCRIPTION
## Summary

- Migrate from `@notionhq/client` v2.x to v5.x which uses the new Notion API version 2025-09-03
- The new API separates databases (containers) from data sources (queryable tables)
- Add `getDataSourceId()` helper to fetch and cache `data_source_id` from database
- Update monster and character sync to use `dataSources.query` instead of `databases.query`
- Add `@notionhq/client` to `serverExternalPackages` in Next.js config to prevent bundling issues

## Test plan

- [x] Tested monster sync from Notion
- [x] Tested character sync from Notion
- [x] Verify sync works in production after deploy

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)