### PR TITLE
feat: Death saving throws for players (MJ only)

### DIFF
--- a/components/combat-panel.tsx
+++ b/components/combat-panel.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react"
 import { useDroppable } from "@dnd-kit/core"
-import { Swords, Play, Square, SkipForward, Minus, Plus, Crown, Zap, X, Trash2 } from "lucide-react"
+import { Swords, Play, Square, SkipForward, Minus, Plus, Crown, Zap, X, Trash2, Skull, Heart, Check, XCircle } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -37,6 +37,7 @@ interface CombatPanelProps {
   onUpdateHp?: (id: string, change: number, type: "player" | "monster") => void
   onUpdateConditions?: (id: string, conditions: string[], type: "player" | "monster", conditionDurations?: Record<string, number>) => void
   onUpdateExhaustion?: (id: string, level: number, type: "player" | "monster") => void
+  onUpdateDeathSaves?: (id: string, type: "player" | "monster", deathSaves: { successes: number; failures: number }, isStabilized: boolean, isDead: boolean) => void
   onRemoveFromCombat?: (id: string) => void
   mode: "mj" | "joueur"
   ownCharacterIds?: string[] // IDs of characters owned by the current player
@@ -54,6 +55,7 @@ export function CombatPanel({
   onUpdateHp,
   onUpdateConditions,
   onUpdateExhaustion,
+  onUpdateDeathSaves,
   onRemoveFromCombat,
   mode,
   ownCharacterIds = [],
@@ -275,6 +277,101 @@ export function CombatPanel({
                             />
                           </div>
                         </div>
+                      )}
+
+                      {/* Death Saving Throws - MJ view */}
+                      {mode === "mj" && participant.type === "player" && participant.currentHp === 0 && !participant.isDead && onUpdateDeathSaves && (
+                        <div className="mt-2 p-2 bg-crimson/10 rounded-lg border border-crimson/30">
+                          <div className="flex items-center gap-2 mb-2">
+                            <Skull className="w-4 h-4 text-crimson" />
+                            <span className="text-xs font-medium text-crimson">Jets de sauvegarde contre la mort</span>
+                            {participant.isStabilized && (
+                              <Badge className="ml-auto bg-gold/20 text-gold border-gold/30 text-xs">
+                                <Heart className="w-3 h-3 mr-1" />
+                                Stabilisé
+                              </Badge>
+                            )}
+                          </div>
+                          <div className="flex items-center gap-4">
+                            {/* Successes */}
+                            <div className="flex items-center gap-1">
+                              <span className="text-xs text-emerald mr-1">Succès:</span>
+                              {[0, 1, 2].map((i) => (
+                                <button
+                                  key={`success-${i}`}
+                                  onClick={() => {
+                                    const currentSuccesses = participant.deathSaves?.successes ?? 0
+                                    const newSuccesses = i < currentSuccesses ? i : i + 1
+                                    const isStabilized = newSuccesses >= 3
+                                    onUpdateDeathSaves(
+                                      participant.id,
+                                      participant.type,
+                                      { successes: Math.min(3, newSuccesses), failures: participant.deathSaves?.failures ?? 0 },
+                                      isStabilized,
+                                      false
+                                    )
+                                  }}
+                                  className={cn(
+                                    "w-5 h-5 rounded-full border-2 transition-all",
+                                    i < (participant.deathSaves?.successes ?? 0)
+                                      ? "bg-emerald border-emerald"
+                                      : "border-emerald/50 hover:border-emerald"
+                                  )}
+                                >
+                                  {i < (participant.deathSaves?.successes ?? 0) && (
+                                    <Check className="w-3 h-3 text-background mx-auto" />
+                                  )}
+                                </button>
+                              ))}
+                            </div>
+                            {/* Failures */}
+                            <div className="flex items-center gap-1">
+                              <span className="text-xs text-crimson mr-1">Échecs:</span>
+                              {[0, 1, 2].map((i) => (
+                                <button
+                                  key={`failure-${i}`}
+                                  onClick={() => {
+                                    const currentFailures = participant.deathSaves?.failures ?? 0
+                                    const newFailures = i < currentFailures ? i : i + 1
+                                    const isDead = newFailures >= 3
+                                    onUpdateDeathSaves(
+                                      participant.id,
+                                      participant.type,
+                                      { successes: participant.deathSaves?.successes ?? 0, failures: Math.min(3, newFailures) },
+                                      participant.isStabilized ?? false,
+                                      isDead
+                                    )
+                                  }}
+                                  className={cn(
+                                    "w-5 h-5 rounded-full border-2 transition-all",
+                                    i < (participant.deathSaves?.failures ?? 0)
+                                      ? "bg-crimson border-crimson"
+                                      : "border-crimson/50 hover:border-crimson"
+                                  )}
+                                >
+                                  {i < (participant.deathSaves?.failures ?? 0) && (
+                                    <XCircle className="w-3 h-3 text-background mx-auto" />
+                                  )}
+                                </button>
+                              ))}
+                            </div>
+                          </div>
+                        </div>
+                      )}
+
+                      {/* Dead indicator */}
+                      {participant.isDead && (
+                        <div className="mt-2 flex items-center gap-2 text-crimson">
+                          <Skull className="w-4 h-4" />
+                          <span className="text-xs font-medium">Mort</span>
+                        </div>
+                      )}
+
+                      {/* Player view - dying indicator (minimal info) */}
+                      {mode === "joueur" && participant.type === "player" && participant.currentHp === 0 && !participant.isDead && !participant.isStabilized && (
+                        <Badge className="mt-2 bg-crimson/20 text-crimson border-crimson/30">
+                          Mourant
+                        </Badge>
                       )}
                     </div>
 

--- a/lib/socket-context/SocketProvider.tsx
+++ b/lib/socket-context/SocketProvider.tsx
@@ -13,6 +13,7 @@ import type {
   HpChangeData,
   ConditionChangeData,
   ExhaustionChangeData,
+  DeathSaveChangeData,
   AmbientEffectData,
   PlayerPositionData,
   NotificationData,
@@ -160,6 +161,17 @@ export function SocketProvider({ children }: SocketProviderProps) {
       });
     });
 
+    socket.on('death-save-change', (data) => {
+      dispatch({
+        type: 'DEATH_SAVE_CHANGE',
+        participantId: data.participantId,
+        participantType: data.participantType,
+        deathSaves: data.deathSaves,
+        isStabilized: data.isStabilized,
+        isDead: data.isDead,
+      });
+    });
+
     socket.on('request-state-sync', () => {
       // DM should respond with current state
       if (stateRef.current.mode === 'mj' && stateRef.current.combatState.active) {
@@ -211,6 +223,7 @@ export function SocketProvider({ children }: SocketProviderProps) {
       socket.off('hp-change');
       socket.off('condition-change');
       socket.off('exhaustion-change');
+      socket.off('death-save-change');
       socket.off('request-state-sync');
       socket.off('ambient-effect');
       socket.off('player-positions');
@@ -325,6 +338,13 @@ export function SocketProvider({ children }: SocketProviderProps) {
     socket.emit('exhaustion-change', data);
   }, []);
 
+  const emitDeathSaveChange = useCallback((data: DeathSaveChangeData) => {
+    const socket = socketRef.current;
+    if (!socket?.connected) return;
+
+    socket.emit('death-save-change', data);
+  }, []);
+
   const emitAmbientEffect = useCallback((data: AmbientEffectData) => {
     const socket = socketRef.current;
     if (!socket?.connected) return;
@@ -374,6 +394,7 @@ export function SocketProvider({ children }: SocketProviderProps) {
     emitHpChange,
     emitConditionChange,
     emitExhaustionChange,
+    emitDeathSaveChange,
     emitAmbientEffect,
     emitPlayerPositions,
     requestPlayerPositions,

--- a/lib/socket-context/reducer.ts
+++ b/lib/socket-context/reducer.ts
@@ -323,6 +323,25 @@ export function socketReducer(state: SocketState, action: SocketAction): SocketS
       };
     }
 
+    case 'DEATH_SAVE_CHANGE': {
+      const { participantId, participantType, deathSaves, isStabilized, isDead } = action;
+
+      // Update in combat participants only (death saves are combat-specific)
+      const participants = state.combatState.participants.map((p) =>
+        p.id === participantId && p.type === participantType
+          ? { ...p, deathSaves, isStabilized, isDead }
+          : p
+      );
+
+      return {
+        ...state,
+        combatState: {
+          ...state.combatState,
+          participants,
+        },
+      };
+    }
+
     // ============ EFFECTS ============
     case 'SET_AMBIENT_EFFECT':
       return {

--- a/lib/socket-context/types.ts
+++ b/lib/socket-context/types.ts
@@ -9,6 +9,7 @@ import type {
   HpChangeData,
   ConditionChangeData,
   ExhaustionChangeData,
+  DeathSaveChangeData,
 } from '../socket-events';
 import type { Character, Monster, CombatParticipant } from '../types';
 
@@ -22,6 +23,7 @@ export type {
   HpChangeData,
   ConditionChangeData,
   ExhaustionChangeData,
+  DeathSaveChangeData,
 };
 
 // Typed socket
@@ -99,6 +101,7 @@ export type SocketAction =
   | { type: 'HP_CHANGE'; participantId: string; participantType: 'player' | 'monster'; newHp: number }
   | { type: 'CONDITION_CHANGE'; participantId: string; participantType: 'player' | 'monster'; conditions: string[]; conditionDurations?: Record<string, number> }
   | { type: 'EXHAUSTION_CHANGE'; participantId: string; participantType: 'player' | 'monster'; exhaustionLevel: number }
+  | { type: 'DEATH_SAVE_CHANGE'; participantId: string; participantType: 'player' | 'monster'; deathSaves: { successes: number; failures: number }; isStabilized: boolean; isDead: boolean }
 
   // Effects
   | { type: 'SET_AMBIENT_EFFECT'; effect: AmbientEffectData['effect'] }
@@ -175,6 +178,7 @@ export interface SocketContextType {
   emitHpChange: (data: HpChangeData) => void;
   emitConditionChange: (data: ConditionChangeData) => void;
   emitExhaustionChange: (data: ExhaustionChangeData) => void;
+  emitDeathSaveChange: (data: DeathSaveChangeData) => void;
 
   // Ambient effect
   emitAmbientEffect: (data: AmbientEffectData) => void;

--- a/lib/socket-events.ts
+++ b/lib/socket-events.ts
@@ -138,6 +138,14 @@ export interface ExhaustionChangeData {
   exhaustionLevel: number;
 }
 
+export interface DeathSaveChangeData {
+  participantId: string;
+  participantType: 'player' | 'monster';
+  deathSaves: { successes: number; failures: number };
+  isStabilized: boolean;
+  isDead: boolean;
+}
+
 export interface AmbientEffectData {
   effect: 'none' | 'rain' | 'fog' | 'fire' | 'snow' | 'sandstorm';
 }
@@ -173,6 +181,7 @@ export interface ServerToClientEvents {
   // Condition and state events
   'condition-change': (data: ConditionChangeData) => void;
   'exhaustion-change': (data: ExhaustionChangeData) => void;
+  'death-save-change': (data: DeathSaveChangeData) => void;
   'ambient-effect': (data: AmbientEffectData) => void;
   // Map position events
   'player-positions': (data: PlayerPositionsData) => void;
@@ -197,6 +206,7 @@ export interface ClientToServerEvents {
   // Condition and state events
   'condition-change': (data: ConditionChangeData) => void;
   'exhaustion-change': (data: ExhaustionChangeData) => void;
+  'death-save-change': (data: DeathSaveChangeData) => void;
   'ambient-effect': (data: AmbientEffectData) => void;
   // Map position events
   'player-positions': (data: PlayerPositionsData) => void;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -39,6 +39,13 @@ export interface CombatParticipant {
   exhaustionLevel: number
   type: "player" | "monster"
   xp?: number // XP value for monsters (from challenge_rating_xp)
+  // Death saving throws (players only)
+  deathSaves?: {
+    successes: number // 0-3
+    failures: number  // 0-3
+  }
+  isStabilized?: boolean
+  isDead?: boolean
 }
 
 export interface Note {

--- a/server.ts
+++ b/server.ts
@@ -122,6 +122,14 @@ interface ExhaustionChangeData {
   exhaustionLevel: number;
 }
 
+interface DeathSaveChangeData {
+  participantId: string;
+  participantType: 'player' | 'monster';
+  deathSaves: { successes: number; failures: number };
+  isStabilized: boolean;
+  isDead: boolean;
+}
+
 interface AmbientEffectData {
   effect: 'none' | 'rain' | 'fog' | 'fire' | 'snow' | 'sandstorm';
 }
@@ -362,6 +370,15 @@ app.prepare().then(() => {
         const room = `campaign-${socket.data.campaignId}`;
         io.to(room).emit('exhaustion-change', data);
         console.log(`[Socket.io] Exhaustion change in ${room}:`, data.participantId);
+      }
+    });
+
+    // Death saving throw changes
+    socket.on('death-save-change', (data: DeathSaveChangeData) => {
+      if (socket.data.campaignId) {
+        const room = `campaign-${socket.data.campaignId}`;
+        io.to(room).emit('death-save-change', data);
+        console.log(`[Socket.io] Death save change in ${room}:`, data.participantId);
       }
     });
 


### PR DESCRIPTION
## Summary
- Implement D&D 5e death saving throws with real-time WebSocket sync
- MJ can toggle success/failure checkboxes for dying players (0 HP)
- 3 successes = stabilized, 3 failures = dead
- Players see only "Mourant" badge (no death save details visible)

## Files changed
- `lib/types.ts` - Added deathSaves, isStabilized, isDead fields to CombatParticipant
- `server.ts` - Added death-save-change WebSocket event handler
- `lib/socket-events.ts` - Added DeathSaveChangeData interface
- `lib/socket-context/*` - Added reducer, provider, and type support
- `app/page.tsx` - Added updateDeathSaves function
- `components/combat-panel.tsx` - Added death save UI with clickable checkboxes

## Test plan
- [ ] Start combat with a player at 0 HP
- [ ] Verify MJ sees death save checkboxes (green for success, red for failure)
- [ ] Click checkboxes to toggle success/failure states
- [ ] Verify 3 successes shows "Stabilisé" badge
- [ ] Verify 3 failures shows "Mort" indicator
- [ ] Verify player view only shows "Mourant" badge, not death save details
- [ ] Test real-time sync between multiple connected clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)