### PR TITLE
fix: Update exhaustion rules to D&D 2024

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -217,13 +217,13 @@ export const CONDITIONS: Condition[] = [
   },
 ]
 
-// Exhaustion levels (Épuisement) - D&D 5e
+// Exhaustion levels (Épuisement) - D&D 2024
 export const EXHAUSTION_LEVELS = [
-  { level: 1, effect: "Désavantage aux jets de caractéristique" },
-  { level: 2, effect: "Vitesse réduite de moitié" },
-  { level: 3, effect: "Désavantage aux jets d'attaque et de sauvegarde" },
-  { level: 4, effect: "Maximum de points de vie réduit de moitié" },
-  { level: 5, effect: "Vitesse réduite à 0" },
+  { level: 1, effect: "-2 aux jets de d20, -1,5m de vitesse" },
+  { level: 2, effect: "-4 aux jets de d20, -3m de vitesse" },
+  { level: 3, effect: "-6 aux jets de d20, -4,5m de vitesse" },
+  { level: 4, effect: "-8 aux jets de d20, -6m de vitesse" },
+  { level: 5, effect: "-10 aux jets de d20, -7,5m de vitesse" },
   { level: 6, effect: "Mort" },
 ] as const
 


### PR DESCRIPTION
## Summary
Update exhaustion system from D&D 5e (2014) to D&D 2024 rules.

**Old rules (removed):**
- Level 1: Disadvantage on ability checks
- Level 2: Speed halved
- Level 3: Disadvantage on attack/saving throws
- Level 4: HP max halved
- Level 5: Speed reduced to 0
- Level 6: Death

**New rules (cumulative):**
- Level 1: -2 to d20 rolls, -1.5m speed
- Level 2: -4 to d20 rolls, -3m speed
- Level 3: -6 to d20 rolls, -4.5m speed
- Level 4: -8 to d20 rolls, -6m speed
- Level 5: -10 to d20 rolls, -7.5m speed
- Level 6: Death

Closes #38

## Test plan
- [x] Open condition manager on a character/monster
- [x] Increase exhaustion level and verify new effect descriptions appear
- [x] Check tooltip on exhaustion badge shows correct cumulative effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)