### PR TITLE
fix: Resolve Player mobile showing stale connected players

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -384,28 +384,25 @@ function CombatTrackerContent() {
 
   // Convert connected players to Character format for the UI
   // Flatten characters array from each connected player and add grouping metadata
-  // MJ mode: only show connected players (empty if none connected)
-  // Player mode: show their own characters from players state
-  const displayPlayers: Character[] = mode === 'mj'
-    ? socketState.connectedPlayers.flatMap(player =>
-        player.characters.map((char, idx) => ({
-          id: String(char.odNumber), // Use Notion UUID directly (stored as odNumber for compatibility)
-          name: char.name,
-          class: char.class,
-          level: char.level,
-          currentHp: char.currentHp,
-          maxHp: char.maxHp,
-          ac: char.ac,
-          initiative: char.initiative,
-          conditions: char.conditions || [],
-          exhaustionLevel: char.exhaustionLevel || 0,
-          // Add metadata for grouping
-          playerSocketId: player.socketId,
-          isFirstInGroup: idx === 0,
-          groupSize: player.characters.length,
-        }))
-      )
-    : players
+  // Both MJ and Player modes show connected players from socket state
+  const displayPlayers: Character[] = socketState.connectedPlayers.flatMap(player =>
+    player.characters.map((char, idx) => ({
+      id: String(char.odNumber), // Use Notion UUID directly (stored as odNumber for compatibility)
+      name: char.name,
+      class: char.class,
+      level: char.level,
+      currentHp: char.currentHp,
+      maxHp: char.maxHp,
+      ac: char.ac,
+      initiative: char.initiative,
+      conditions: char.conditions || [],
+      exhaustionLevel: char.exhaustionLevel || 0,
+      // Add metadata for grouping
+      playerSocketId: player.socketId,
+      isFirstInGroup: idx === 0,
+      groupSize: player.characters.length,
+    }))
+  )
 
   // Helper to add history entry
   const addHistoryEntry = (entry: Omit<HistoryEntry, "id" | "timestamp">) => {

--- a/lib/socket-context/SocketProvider.tsx
+++ b/lib/socket-context/SocketProvider.tsx
@@ -315,9 +315,9 @@ export function SocketProvider({ children }: SocketProviderProps) {
     }
   }, [state.isConnected, state.isJoined, state.mode, state.campaignId]);
 
-  // Periodic refresh of connected players for DM (in case socket reconnected and lost room membership)
+  // Periodic refresh of connected players for all modes (in case socket reconnected and lost room membership)
   useEffect(() => {
-    if (!state.isConnected || !state.isJoined || state.mode !== 'mj') return;
+    if (!state.isConnected || !state.isJoined) return;
 
     const socket = socketRef.current;
     if (!socket) return;
@@ -331,7 +331,7 @@ export function SocketProvider({ children }: SocketProviderProps) {
     socket.emit('request-connected-players', { campaignId: state.campaignId });
 
     return () => clearInterval(interval);
-  }, [state.isConnected, state.isJoined, state.mode, state.campaignId]);
+  }, [state.isConnected, state.isJoined, state.campaignId]);
 
   // ============ ACTION FUNCTIONS ============
 


### PR DESCRIPTION
## Summary
- Server: Remove stale Redis entries with same character IDs on player reconnect
- Reducer: Deduplicate PLAYER_CONNECTED by character ID (not just socketId)
- Reducer: Clear connectedPlayers on SET_MODE to prevent stale data between sessions
- Page: Use socketState.connectedPlayers for both MJ and Player modes
- SocketProvider: Enable periodic refresh for all modes (not just DM)

## Test plan
- [ ] Connect as MJ and verify connected players display
- [ ] Connect as Player on mobile and verify only connected players show (not all Notion characters)
- [ ] Disconnect and reconnect player - verify no duplicates
- [ ] Refresh MJ page - verify players are still visible
- [ ] Test with multiple players connecting/disconnecting

🤖 Generated with [Claude Code](https://claude.com/claude-code)