### PR TITLE
feat: HP persistence, quick HP controls, and player character panel

### DIFF
--- a/components/draggable-card.tsx
+++ b/components/draggable-card.tsx
@@ -41,7 +41,9 @@ export function DraggablePlayerCard({ player, isInCombat, compact = false, onUpd
 
   const handleInitiativeBlur = () => {
     setIsEditingInit(false)
-    const newInit = Math.min(30, Math.max(1, parseInt(initValue) || 1))
+    const parsed = parseInt(initValue)
+    // Allow 0 as a valid value (unset), otherwise clamp between 1-20
+    const newInit = isNaN(parsed) || parsed < 0 ? 0 : Math.min(20, parsed)
     setInitValue(String(newInit))
     if (onUpdateInitiative && newInit !== player.initiative) {
       onUpdateInitiative(newInit)
@@ -95,7 +97,7 @@ export function DraggablePlayerCard({ player, isInCombat, compact = false, onUpd
           <Input
             type="number"
             min={1}
-            max={30}
+            max={20}
             value={initValue}
             onChange={(e) => handleInitiativeChange(e.target.value)}
             onBlur={handleInitiativeBlur}
@@ -132,7 +134,7 @@ export function DraggablePlayerCard({ player, isInCombat, compact = false, onUpd
             title={onUpdateInitiative && !isInCombat ? "Cliquez pour modifier l'initiative" : undefined}
             disabled={isInCombat}
           >
-            {player.initiative ?? "?"}
+            {player.initiative || "?"}
           </button>
         )}
         <div className="flex-1 min-w-0">
@@ -332,7 +334,7 @@ export function SortableParticipantCard({ participant, onRemove, onUpdateInitiat
 
   const handleInitiativeBlur = () => {
     setIsEditingInit(false)
-    const newInit = Math.min(30, Math.max(1, parseInt(initValue) || 1))
+    const newInit = Math.min(20, Math.max(1, parseInt(initValue) || 1))
     setInitValue(String(newInit))
     if (onUpdateInitiative && newInit !== participant.initiative) {
       onUpdateInitiative(newInit)
@@ -378,7 +380,7 @@ export function SortableParticipantCard({ participant, onRemove, onUpdateInitiat
           <Input
             type="number"
             min={1}
-            max={30}
+            max={20}
             value={initValue}
             onChange={(e) => handleInitiativeChange(e.target.value)}
             onBlur={handleInitiativeBlur}
@@ -409,9 +411,9 @@ export function SortableParticipantCard({ participant, onRemove, onUpdateInitiat
         )}
 
         {/* Info */}
-        <div className="flex-1 min-w-0">
+        <div className="flex-1 min-w-0 overflow-hidden">
           <div className="flex items-center gap-2">
-            <span className="text-xs text-muted-foreground">#{index + 1}</span>
+            <span className="text-xs text-muted-foreground shrink-0">#{index + 1}</span>
             <h3 className={cn(
               "font-semibold truncate",
               isPlayer ? "text-foreground" : "text-crimson"
@@ -419,7 +421,7 @@ export function SortableParticipantCard({ participant, onRemove, onUpdateInitiat
               {participant.name}
             </h3>
             {!isPlayer && (
-              <Badge variant="outline" className="text-xs border-crimson/30 text-crimson px-1.5 py-0">
+              <Badge variant="outline" className="text-xs border-crimson/30 text-crimson px-1.5 py-0 shrink-0 hidden sm:flex">
                 Monstre
               </Badge>
             )}
@@ -451,11 +453,11 @@ export function SortableParticipantCard({ participant, onRemove, onUpdateInitiat
           )}
         </div>
 
-        {/* Remove Button */}
+        {/* Remove Button - always visible on mobile, hover on desktop */}
         <Button
           variant="ghost"
           size="icon"
-          className="h-8 w-8 text-muted-foreground hover:text-crimson hover:bg-crimson/10 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
+          className="h-8 w-8 text-muted-foreground hover:text-crimson hover:bg-crimson/10 shrink-0 md:opacity-0 md:group-hover:opacity-100 transition-opacity"
           onClick={(e) => {
             e.stopPropagation()
             onRemove()

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -29,7 +29,7 @@ export function MobileNav({ activeTab, onTabChange, mode, currentPage = "home", 
       ]
 
   const playerTabs = [
-    { id: "players" as const, label: "Groupe", icon: Users },
+    { id: "players" as const, label: "Perso", icon: Users },
     { id: "combat" as const, label: "Combat", icon: Swords },
   ]
 

--- a/components/monster-picker-panel.tsx
+++ b/components/monster-picker-panel.tsx
@@ -38,29 +38,29 @@ function DraggableDbMonsterCard({ monster, onAddClick, onViewClick }: DraggableD
       }
     : undefined
 
+  const isMobileDevice = typeof window !== 'undefined' && window.innerWidth < 768
+
   return (
     <div
       ref={setNodeRef}
       style={style}
-      {...attributes}
-      {...listeners}
+      {...(isMobileDevice ? {} : { ...attributes, ...listeners })}
       className={cn(
-        "group w-full text-left p-2 rounded-lg bg-secondary/30 hover:bg-secondary/50 border-2 transition-all touch-none select-none",
+        "group w-full text-left p-2 rounded-lg bg-secondary/30 hover:bg-secondary/50 border-2 transition-all select-none",
         isDragging
           ? "opacity-50 border-crimson/50 z-50"
           : "border-transparent hover:border-crimson/30",
-        "cursor-grab active:cursor-grabbing"
+        !isMobileDevice && "touch-none cursor-grab active:cursor-grabbing"
       )}
     >
       <div className="flex items-center gap-2">
-        {/* Drag Handle - visible on hover */}
-        <div className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+        {/* Drag Handle - visible on hover, hidden on mobile */}
+        <div className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity hidden md:block">
           <GripVertical className="w-4 h-4 text-muted-foreground" />
         </div>
 
         {/* Monster Info */}
         <div className="flex items-center gap-2 flex-1 min-w-0">
-
           {monster.image_url && (
             <div className="w-8 h-8 rounded overflow-hidden border border-border shrink-0">
               {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -71,7 +71,7 @@ function DraggableDbMonsterCard({ monster, onAddClick, onViewClick }: DraggableD
               />
             </div>
           )}
-          <div className="min-w-0">
+          <div className="min-w-0 flex-1">
             <div className="font-medium text-sm truncate">{monster.name}</div>
             <div className="text-xs text-muted-foreground truncate">
               {monster.creature_type}
@@ -81,7 +81,7 @@ function DraggableDbMonsterCard({ monster, onAddClick, onViewClick }: DraggableD
 
         {/* Stats and Action Buttons */}
         <div className="flex items-center gap-1 shrink-0">
-          <Badge variant="outline" className="text-xs border-crimson/30 text-crimson">
+          <Badge variant="outline" className="text-xs border-crimson/30 text-crimson hidden sm:flex">
             PV {monster.hit_points}
           </Badge>
           <Button
@@ -97,14 +97,13 @@ function DraggableDbMonsterCard({ monster, onAddClick, onViewClick }: DraggableD
           </Button>
           <Button
             size="icon"
-            variant="ghost"
-            className="h-8 w-8 text-crimson hover:bg-crimson/20"
+            className="h-9 w-9 bg-crimson hover:bg-crimson/80 text-white"
             onClick={(e) => {
               e.stopPropagation()
               onAddClick(monster, e)
             }}
           >
-            <Plus className="w-4 h-4" />
+            <Plus className="w-5 h-5" />
           </Button>
         </div>
       </div>

--- a/components/my-characters-panel.tsx
+++ b/components/my-characters-panel.tsx
@@ -1,0 +1,232 @@
+"use client"
+
+import { useState } from "react"
+import { User, Shield, Heart, Minus, Plus, Zap, HeartPulse } from "lucide-react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Badge } from "@/components/ui/badge"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { cn } from "@/lib/utils"
+import type { Character } from "@/lib/types"
+import { ConditionList } from "@/components/condition-badge"
+
+interface MyCharactersPanelProps {
+  characters: Character[]
+  onUpdateHp: (id: string, change: number) => void
+  combatActive?: boolean
+}
+
+const QUICK_HP_VALUES = [1, 3, 5, 10]
+
+export function MyCharactersPanel({ characters, onUpdateHp, combatActive = false }: MyCharactersPanelProps) {
+  const [hpChange, setHpChange] = useState<Record<string, string>>({})
+
+  const getHpColor = (current: number, max: number) => {
+    const ratio = current / max
+    if (ratio > 0.5) return "bg-emerald"
+    if (ratio > 0.25) return "bg-gold"
+    return "bg-crimson"
+  }
+
+  const getHpTextColor = (current: number, max: number) => {
+    const ratio = current / max
+    if (ratio > 0.5) return "text-emerald"
+    if (ratio > 0.25) return "text-gold"
+    return "text-crimson"
+  }
+
+  const handleDamage = (characterId: string) => {
+    const value = Number.parseInt(hpChange[characterId] || "0")
+    if (value > 0) {
+      onUpdateHp(characterId, -Math.abs(value))
+      setHpChange({ ...hpChange, [characterId]: "" })
+    }
+  }
+
+  const handleHeal = (characterId: string) => {
+    const value = Number.parseInt(hpChange[characterId] || "0")
+    if (value > 0) {
+      onUpdateHp(characterId, Math.abs(value))
+      setHpChange({ ...hpChange, [characterId]: "" })
+    }
+  }
+
+  const handleFullHp = (character: Character) => {
+    const hpToRestore = character.maxHp - character.currentHp
+    if (hpToRestore > 0) {
+      onUpdateHp(character.id, hpToRestore)
+    }
+  }
+
+  if (characters.length === 0) {
+    return (
+      <Card className="bg-card border-border h-full flex flex-col">
+        <CardHeader className="pb-3 shrink-0">
+          <CardTitle className="flex items-center gap-2 text-gold">
+            <User className="w-5 h-5" />
+            Mes Personnages
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="flex-1 flex items-center justify-center">
+          <div className="text-center text-muted-foreground py-8">
+            <User className="w-12 h-12 mx-auto mb-3 opacity-30" />
+            <p>Aucun personnage sélectionné</p>
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card className="bg-card border-border h-full flex flex-col">
+      <CardHeader className="pb-3 shrink-0">
+        <CardTitle className="flex items-center gap-2 text-gold">
+          <User className="w-5 h-5" />
+          Mes Personnages
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="flex-1 overflow-hidden p-0">
+        <ScrollArea className="h-full px-4 md:px-6 pb-6">
+          <div className="space-y-4">
+            {characters.map((character) => (
+              <div
+                key={character.id}
+                className="bg-secondary/30 rounded-lg border border-border/50 overflow-hidden"
+              >
+                {/* Character Header */}
+                <div className="p-4 border-b border-border/30">
+                  <div className="flex items-center justify-between mb-2">
+                    <h3 className="font-bold text-lg text-foreground">{character.name}</h3>
+                    <Badge variant="outline" className="border-gold/50 text-gold">
+                      <Shield className="w-3 h-3 mr-1" />
+                      CA {character.ac}
+                    </Badge>
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    {character.class} Niveau {character.level}
+                  </p>
+                </div>
+
+                {/* HP Section */}
+                <div className="p-4 bg-secondary/20">
+                  <div className="flex items-center gap-2 mb-3">
+                    <Heart className="w-5 h-5 text-crimson" />
+                    <span className="text-sm font-medium text-muted-foreground">Points de vie</span>
+                  </div>
+
+                  {/* HP Display */}
+                  <div className="mb-4">
+                    <div className="flex justify-between items-baseline mb-2">
+                      <span className={cn(
+                        "text-3xl font-bold",
+                        getHpTextColor(character.currentHp, character.maxHp)
+                      )}>
+                        {character.currentHp}
+                      </span>
+                      <span className="text-lg text-muted-foreground">/ {character.maxHp}</span>
+                    </div>
+                    <div className="h-3 bg-muted rounded-full overflow-hidden">
+                      <div
+                        className={cn(
+                          "h-full transition-all duration-500 ease-out",
+                          getHpColor(character.currentHp, character.maxHp)
+                        )}
+                        style={{ width: `${Math.max(0, (character.currentHp / character.maxHp) * 100)}%` }}
+                      />
+                    </div>
+                  </div>
+
+                  {/* HP Controls */}
+                  <div className="space-y-3">
+                    {/* Full HP Button */}
+                    <Button
+                      className="w-full min-h-[40px] bg-emerald/20 hover:bg-emerald/30 text-emerald border border-emerald/30 active:scale-95 transition-smooth"
+                      onClick={() => handleFullHp(character)}
+                      disabled={character.currentHp >= character.maxHp}
+                    >
+                      <HeartPulse className="w-4 h-4 mr-2" />
+                      Vie complète
+                    </Button>
+
+                    {/* Quick HP Buttons */}
+                    <div className="grid grid-cols-4 gap-1">
+                      {QUICK_HP_VALUES.map((value) => (
+                        <Button
+                          key={`damage-${value}`}
+                          variant="outline"
+                          size="sm"
+                          className="h-9 text-crimson border-crimson/30 hover:bg-crimson/10 hover:border-crimson/50 active:scale-95"
+                          onClick={() => onUpdateHp(character.id, -value)}
+                        >
+                          -{value}
+                        </Button>
+                      ))}
+                    </div>
+                    <div className="grid grid-cols-4 gap-1">
+                      {QUICK_HP_VALUES.map((value) => (
+                        <Button
+                          key={`heal-${value}`}
+                          variant="outline"
+                          size="sm"
+                          className="h-9 text-emerald border-emerald/30 hover:bg-emerald/10 hover:border-emerald/50 active:scale-95"
+                          onClick={() => onUpdateHp(character.id, value)}
+                        >
+                          +{value}
+                        </Button>
+                      ))}
+                    </div>
+
+                    {/* Custom Amount */}
+                    <div className="flex gap-2">
+                      <Input
+                        type="number"
+                        min="1"
+                        value={hpChange[character.id] || ""}
+                        onChange={(e) => setHpChange({ ...hpChange, [character.id]: e.target.value })}
+                        placeholder="Autre..."
+                        className="text-center font-semibold bg-background"
+                      />
+                      <Button
+                        variant="destructive"
+                        size="icon"
+                        className="shrink-0 bg-crimson hover:bg-crimson/80 active:scale-95"
+                        onClick={() => handleDamage(character.id)}
+                        disabled={!hpChange[character.id] || Number.parseInt(hpChange[character.id]) <= 0}
+                      >
+                        <Minus className="w-4 h-4" />
+                      </Button>
+                      <Button
+                        size="icon"
+                        className="shrink-0 bg-emerald hover:bg-emerald/80 text-background active:scale-95"
+                        onClick={() => handleHeal(character.id)}
+                        disabled={!hpChange[character.id] || Number.parseInt(hpChange[character.id]) <= 0}
+                      >
+                        <Plus className="w-4 h-4" />
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Conditions */}
+                {(character.conditions.length > 0 || character.exhaustionLevel > 0) && (
+                  <div className="p-4 border-t border-border/30">
+                    <div className="flex items-center gap-2 mb-2">
+                      <Zap className="w-4 h-4 text-purple-500" />
+                      <span className="text-sm font-medium text-muted-foreground">États</span>
+                    </div>
+                    <ConditionList
+                      conditions={character.conditions}
+                      exhaustionLevel={character.exhaustionLevel}
+                      size="md"
+                    />
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </ScrollArea>
+      </CardContent>
+    </Card>
+  )
+}

--- a/docker/init-db/12-participant-type.sql
+++ b/docker/init-db/12-participant-type.sql
@@ -1,0 +1,9 @@
+-- Add participant_type column to fight_preset_monsters
+-- This allows distinguishing between players and monsters when loading presets
+
+ALTER TABLE fight_preset_monsters
+ADD COLUMN IF NOT EXISTS participant_type VARCHAR(20) NOT NULL DEFAULT 'monster';
+
+-- Add reference_id to store the original player/monster ID
+ALTER TABLE fight_preset_monsters
+ADD COLUMN IF NOT EXISTS reference_id VARCHAR(50);

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -752,6 +752,8 @@ export interface FightPresetMonster {
   initiative: number;
   notes: string | null;
   quantity: number;
+  participant_type: 'player' | 'monster';
+  reference_id: string | null;
   created_at: Date;
 }
 
@@ -807,8 +809,8 @@ export async function createFightPreset(
   for (const monster of monsters) {
     const monsterResult = await pool.query(
       `INSERT INTO fight_preset_monsters
-       (preset_id, monster_id, name, hp, max_hp, ac, initiative, notes, quantity)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING *`,
+       (preset_id, monster_id, name, hp, max_hp, ac, initiative, notes, quantity, participant_type, reference_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) RETURNING *`,
       [
         preset.id,
         monster.monster_id,
@@ -819,6 +821,8 @@ export async function createFightPreset(
         monster.initiative,
         monster.notes,
         monster.quantity || 1,
+        monster.participant_type || 'monster',
+        monster.reference_id || null,
       ]
     );
     insertedMonsters.push(monsterResult.rows[0]);

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -150,6 +150,27 @@ export async function clearConnectedPlayers(campaignId: number): Promise<void> {
   await client.del(KEYS.players(campaignId));
 }
 
+// Update a specific character's HP across all connected players
+export async function updateCharacterHp(campaignId: number, characterId: string, newHp: number): Promise<void> {
+  const client = await getRedis();
+  const players = await getConnectedPlayers(campaignId);
+
+  for (const player of players) {
+    let updated = false;
+    for (const char of player.characters) {
+      if (String(char.odNumber) === characterId) {
+        char.currentHp = newHp;
+        updated = true;
+        break;
+      }
+    }
+    if (updated) {
+      await client.hSet(KEYS.players(campaignId), player.socketId, JSON.stringify(player));
+      break;
+    }
+  }
+}
+
 // ============================================
 // Combat State Operations
 // ============================================

--- a/lib/socket-context/SocketProvider.tsx
+++ b/lib/socket-context/SocketProvider.tsx
@@ -311,7 +311,11 @@ export function SocketProvider({ children }: SocketProviderProps) {
         role: 'dm',
         password: storedPassword,
       });
-      // JOIN_SUCCESS will be dispatched when connected-players is received
+      // Dispatch JOIN_SUCCESS immediately so periodic refresh starts
+      // Server will send connected-players which will update the player list
+      dispatch({ type: 'JOIN_SUCCESS' });
+    } else {
+      console.log('[Socket] No stored DM password, cannot auto-rejoin');
     }
   }, [state.isConnected, state.isJoined, state.mode, state.campaignId]);
 


### PR DESCRIPTION
## Summary
- Add **MyCharactersPanel** for player view (mobile & desktop) showing own characters with HP controls
- **Persist player HP changes to Redis** for session persistence across page refreshes
- **Preserve HP when adding players to new combats** (instead of resetting to max)
- Add **quick HP buttons** (-1, -3, -5, -10 and +1, +3, +5, +10) across all panels
- Add **Vie complète (Full HP) button** to restore characters to max HP
- Update mobile nav to show Perso tab for players instead of Groupe
- Fix DM auto-rejoin to dispatch JOIN_SUCCESS immediately
- Add participant_type column to fight presets for proper player/monster distinction
- Various mobile UI improvements and HP visibility fixes

## Test plan
- [ ] Test player view on mobile - Perso tab should show character with HP controls
- [ ] Test player view on desktop - MyCharactersPanel should appear on the left
- [ ] Test HP persistence - change HP, refresh page, HP should be preserved
- [ ] Test quick HP buttons (-1, -3, -5, -10 and +1, +3, +5, +10)
- [ ] Test Vie complète button restores full HP
- [ ] Test starting new combat preserves current HP (does not reset to max)
- [ ] Test DM reconnection after page refresh

Generated with Claude Code