### PR TITLE
fix: Mobile UI improvements for combat tracker

### DIFF
--- a/components/bestiary-panel.tsx
+++ b/components/bestiary-panel.tsx
@@ -166,8 +166,9 @@ export function BestiaryPanel({ onAddMonsterToCombat, mode }: BestiaryPanelProps
                     className="p-3 rounded-lg bg-secondary/30 hover:bg-secondary/50 border border-transparent hover:border-gold/30 transition-colors cursor-pointer"
                   >
                     <div className="flex items-center gap-3">
+                      {/* Hide image on mobile to save space */}
                       {monster.image_url && (
-                        <div className="w-10 h-10 rounded overflow-hidden border border-border shrink-0">
+                        <div className="w-10 h-10 rounded overflow-hidden border border-border shrink-0 hidden sm:block">
                           {/* eslint-disable-next-line @next/next/no-img-element */}
                           <img
                             src={monster.image_url}

--- a/components/combat-panel.tsx
+++ b/components/combat-panel.tsx
@@ -206,11 +206,11 @@ export function CombatPanel({
                     index === 0 && "animate-fade-in"
                   )}
                 >
-                  <div className="flex items-center gap-3">
-                    {/* Initiative Badge */}
+                  <div className="flex items-center gap-2 md:gap-3">
+                    {/* Initiative Badge - smaller on mobile */}
                     <div
                       className={cn(
-                        "w-11 h-11 rounded-lg flex items-center justify-center font-bold text-lg shrink-0 transition-smooth",
+                        "w-9 h-9 md:w-11 md:h-11 rounded-lg flex items-center justify-center font-bold text-sm md:text-lg shrink-0 transition-smooth",
                         index === currentTurn
                           ? participant.type === "monster"
                             ? "bg-crimson text-white"
@@ -238,7 +238,7 @@ export function CombatPanel({
                           <Crown className="w-4 h-4 text-gold flex-shrink-0 animate-bounce" />
                         )}
                         {participant.type === "monster" && (
-                          <Badge variant="outline" className="text-xs border-crimson/50 text-crimson">
+                          <Badge variant="outline" className="text-xs border-crimson/50 text-crimson hidden sm:flex">
                             Monstre
                           </Badge>
                         )}
@@ -383,15 +383,15 @@ export function CombatPanel({
                       )}
                     </div>
 
-                    {/* Actions */}
+                    {/* Actions - more compact on mobile */}
                     {mode === "mj" && (
-                      <div className="flex gap-1 shrink-0">
+                      <div className="flex gap-0.5 md:gap-1 shrink-0">
                         {/* Remove from combat */}
                         {onRemoveFromCombat && (
                           <Button
                             size="icon"
                             variant="ghost"
-                            className="h-10 w-10 text-muted-foreground hover:text-crimson hover:bg-crimson/10 transition-smooth"
+                            className="h-8 w-8 md:h-10 md:w-10 text-muted-foreground hover:text-crimson hover:bg-crimson/10 transition-smooth"
                             onClick={() => onRemoveFromCombat(participant.id)}
                           >
                             <X className="w-4 h-4" />
@@ -428,7 +428,7 @@ export function CombatPanel({
                               <Button
                                 size="icon"
                                 variant="outline"
-                                className="h-10 w-10 border-border hover:border-purple-500 hover:text-purple-500 bg-transparent transition-smooth"
+                                className="h-8 w-8 md:h-10 md:w-10 border-border hover:border-purple-500 hover:text-purple-500 bg-transparent transition-smooth"
                               >
                                 <Zap className="w-4 h-4" />
                               </Button>
@@ -442,7 +442,7 @@ export function CombatPanel({
                             <Button
                               size="sm"
                               variant="outline"
-                              className="min-h-[40px] border-border hover:border-gold hover:text-gold bg-transparent transition-smooth"
+                              className="h-8 md:min-h-[40px] px-2 md:px-3 border-border hover:border-gold hover:text-gold bg-transparent transition-smooth text-xs md:text-sm"
                               onClick={() => setSelectedParticipant(participant)}
                             >
                               PV

--- a/components/monster-picker-panel.tsx
+++ b/components/monster-picker-panel.tsx
@@ -61,8 +61,9 @@ function DraggableDbMonsterCard({ monster, onAddClick, onViewClick }: DraggableD
 
         {/* Monster Info */}
         <div className="flex items-center gap-2 flex-1 min-w-0">
+          {/* Hide image on mobile to save space */}
           {monster.image_url && (
-            <div className="w-8 h-8 rounded overflow-hidden border border-border shrink-0">
+            <div className="w-8 h-8 rounded overflow-hidden border border-border shrink-0 hidden sm:block">
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 src={monster.image_url}

--- a/components/player-panel.tsx
+++ b/components/player-panel.tsx
@@ -230,7 +230,9 @@ export function PlayerPanel({ players, onUpdateHp, onUpdateInitiative, onUpdateC
               <Button
                 onClick={() => {
                   if (playerToAdd && onAddToCombat) {
-                    const init = parseInt(initiativeValue) || 0
+                    // Clamp initiative between 1-20 like on desktop
+                    const parsed = parseInt(initiativeValue)
+                    const init = isNaN(parsed) || parsed < 1 ? 1 : Math.min(20, parsed)
                     onUpdateInitiative(playerToAdd.id, init)
                     onAddToCombat({ ...playerToAdd, initiative: init })
                     setPlayerToAdd(null)


### PR DESCRIPTION
## Summary
- Fix initiative limit (1-20) when adding player on mobile MJ view
- Make combat panel more compact on mobile (smaller badges, buttons, gaps)
- Hide "Monstre" badge on small screens to save space
- Hide monster images in bestiary quick view on mobile

## Test plan
- [ ] Test adding a player on mobile MJ view - initiative should be clamped 1-20
- [ ] Test combat view on mobile - cards should fit without horizontal overflow
- [ ] Test bestiary on mobile - monster images should be hidden

?? Generated with [Claude Code](https://claude.com/claude-code)