### PR TITLE
feat: Add QR code for easy player connection (#46)

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,12 +1,14 @@
 "use client"
 
+import { useState } from "react"
 import Link from "next/link"
-import { Sword, Settings, Skull, Crown, User, LogOut, Map, Sparkles, Menu } from "lucide-react"
+import { Sword, Settings, Skull, Crown, User, LogOut, Map, Sparkles, Menu, QrCode } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { cn } from "@/lib/utils"
 import { AmbientControls, CriticalButtons, type AmbientEffect } from "@/components/ambient-effects"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { QrCodeDialog } from "@/components/qr-code-dialog"
 
 interface HeaderProps {
   mode: "mj" | "joueur"
@@ -29,6 +31,8 @@ export function Header({
   ambientEffect = "none",
   onAmbientEffectChange,
 }: HeaderProps) {
+  const [showQrDialog, setShowQrDialog] = useState(false)
+
   return (
     <header className="border-b border-border bg-card/80 backdrop-blur-sm sticky top-0 z-40 safe-area-top">
       {/* Main Header Row */}
@@ -88,6 +92,19 @@ export function Header({
                 </div>
               </PopoverContent>
             </Popover>
+          )}
+
+          {/* QR Code Button - DM only */}
+          {mode === "mj" && (
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => setShowQrDialog(true)}
+              className="h-9 w-9 hover:bg-primary/20 hover:text-gold transition-smooth"
+              title="Code QR de connexion"
+            >
+              <QrCode className="w-4 h-4" />
+            </Button>
           )}
 
           {/* User Info Badge */}
@@ -169,15 +186,25 @@ export function Header({
                 >
                   <div className="flex flex-col gap-1">
                     {mode === "mj" && (
-                      <Link href="/monsters" className="w-full">
+                      <>
+                        <Link href="/monsters" className="w-full">
+                          <Button
+                            variant="ghost"
+                            className="w-full justify-start gap-2 h-9 hover:bg-primary/20 hover:text-crimson"
+                          >
+                            <Skull className="w-4 h-4" />
+                            <span className="text-sm">Bestiaire</span>
+                          </Button>
+                        </Link>
                         <Button
                           variant="ghost"
-                          className="w-full justify-start gap-2 h-9 hover:bg-primary/20 hover:text-crimson"
+                          onClick={() => setShowQrDialog(true)}
+                          className="w-full justify-start gap-2 h-9 hover:bg-primary/20 hover:text-gold"
                         >
-                          <Skull className="w-4 h-4" />
-                          <span className="text-sm">Bestiaire</span>
+                          <QrCode className="w-4 h-4" />
+                          <span className="text-sm">Code QR</span>
                         </Button>
-                      </Link>
+                      </>
                     )}
                     <Link href="/map" className="w-full">
                       <Button
@@ -214,6 +241,9 @@ export function Header({
           </Button>
         </div>
       </div>
+
+      {/* QR Code Dialog */}
+      <QrCodeDialog open={showQrDialog} onOpenChange={setShowQrDialog} />
     </header>
   )
 }

--- a/components/qr-code-dialog.tsx
+++ b/components/qr-code-dialog.tsx
@@ -1,0 +1,92 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { QrCode, Copy, Check } from "lucide-react"
+import { QRCodeSVG } from "qrcode.react"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog"
+import { toast } from "sonner"
+
+interface QrCodeDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function QrCodeDialog({ open, onOpenChange }: QrCodeDialogProps) {
+  const [connectionUrl, setConnectionUrl] = useState("")
+  const [copied, setCopied] = useState(false)
+
+  useEffect(() => {
+    if (open && typeof window !== "undefined") {
+      setConnectionUrl(window.location.origin)
+    }
+  }, [open])
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(connectionUrl)
+      setCopied(true)
+      toast.success("URL copiée dans le presse-papier")
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      toast.error("Impossible de copier l'URL")
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="bg-card border-border max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="text-gold flex items-center gap-2">
+            <QrCode className="w-5 h-5" />
+            Code QR de connexion
+          </DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col items-center gap-4 py-4">
+          <p className="text-sm text-muted-foreground text-center">
+            Scannez ce code pour rejoindre la session
+          </p>
+          {connectionUrl && (
+            <div className="p-4 bg-white rounded-lg">
+              <QRCodeSVG
+                value={connectionUrl}
+                size={200}
+                level="M"
+                includeMargin={false}
+              />
+            </div>
+          )}
+          <div className="flex items-center gap-2 w-full">
+            <code className="flex-1 px-3 py-2 bg-background rounded-md text-sm text-muted-foreground truncate">
+              {connectionUrl}
+            </code>
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={handleCopy}
+              className="shrink-0"
+              title="Copier l'URL"
+            >
+              {copied ? (
+                <Check className="w-4 h-4 text-emerald" />
+              ) : (
+                <Copy className="w-4 h-4" />
+              )}
+            </Button>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Fermer
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "next-themes": "^0.4.6",
     "pg": "^8.16.3",
     "pmtiles": "^4.3.0",
+    "qrcode.react": "^4.2.0",
     "react": "19.2.0",
     "react-day-picker": "9.11.2",
     "react-dom": "19.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
       pmtiles:
         specifier: ^4.3.0
         version: 4.3.0
+      qrcode.react:
+        specifier: ^4.2.0
+        version: 4.2.0(react@19.2.0)
       react:
         specifier: 19.2.0
         version: 19.2.0
@@ -2020,6 +2023,11 @@ packages:
 
   protocol-buffers-schema@3.6.0:
     resolution: {integrity: sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==}
+
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   quickselect@3.0.0:
     resolution: {integrity: sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==}
@@ -3943,6 +3951,10 @@ snapshots:
   potpack@2.1.0: {}
 
   protocol-buffers-schema@3.6.0: {}
+
+  qrcode.react@4.2.0(react@19.2.0):
+    dependencies:
+      react: 19.2.0
 
   quickselect@3.0.0: {}
 


### PR DESCRIPTION
## Summary
- Add QR code feature to DM interface for easy player connection
- Players can scan the QR code to join sessions without typing the URL manually
- QR button visible in header (desktop) and mobile menu for DM mode only
- Includes copy-to-clipboard functionality for the URL

## Changes
- Added `qrcode.react` package
- Created `QrCodeDialog` component
- Updated `Header` component with QR button

## Test plan
- [ ] Login as DM (MJ)
- [ ] Click QR code button in header
- [ ] Verify QR code displays correctly
- [ ] Verify URL is correct and can be copied
- [ ] Test on mobile menu as well

Closes #46

?? Generated with [Claude Code](https://claude.com/claude-code)