### PR TITLE
feat: Editable IP address for QR code

### DIFF
--- a/app/api/server-ip/route.ts
+++ b/app/api/server-ip/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server"
+
+export async function GET() {
+  // Use LOCAL_IP environment variable (required for Docker)
+  // Set this in docker-compose.yml or .env file
+  const serverIp = process.env.LOCAL_IP || "192.168.1.2"
+
+  return NextResponse.json({ ip: serverIp })
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -16,6 +16,8 @@ services:
       - WATCHPACK_POLLING=true
       # Tell pnpm we're in CI mode (no TTY prompts)
       - CI=true
+      # Local IP for QR code (set to your machine's local IP)
+      - LOCAL_IP=${LOCAL_IP:-192.168.1.2}
     volumes:
       # Mount source code for hot-reload
       - .:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - DATABASE_URL=postgresql://dnd:dnd@db:5432/dnd_tracker
       # Redis URL for session/state management
       - REDIS_URL=redis://redis:6379
+      # Local IP for QR code (set to your machine's local IP)
+      - LOCAL_IP=${LOCAL_IP:-192.168.1.2}
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary
Improves the QR code feature by allowing the DM to edit and save the server IP address.

## Changes
- Add `/api/server-ip` endpoint for default IP detection
- Add editable IP input field in QR code dialog
- Save custom IP to localStorage for persistence
- QR code updates live as IP is typed
- Add `LOCAL_IP` environment variable to docker-compose files

## Why
When running in Docker, the server can't auto-detect the host's local IP. This allows the DM to manually set the correct IP (e.g., 192.168.1.x) so players can scan the QR code and connect.

?? Generated with [Claude Code](https://claude.com/claude-code)