### PR TITLE
Preprod to Master: Notion parsing & animation sync fixes

### DIFF
--- a/lib/socket-context/SocketProvider.tsx
+++ b/lib/socket-context/SocketProvider.tsx
@@ -197,14 +197,19 @@ export function SocketProvider({ children }: SocketProviderProps) {
 
     socket.on('request-state-sync', () => {
       // DM should respond with current state
-      if (stateRef.current.mode === 'mj' && stateRef.current.combatState.active) {
-        socket.emit('combat-update', {
-          type: 'state-sync',
-          combatActive: stateRef.current.combatState.active,
-          currentTurn: stateRef.current.combatState.currentTurn,
-          roundNumber: stateRef.current.combatState.roundNumber,
-          participants: stateRef.current.combatState.participants,
-        });
+      if (stateRef.current.mode === 'mj') {
+        // Send combat state if active
+        if (stateRef.current.combatState.active) {
+          socket.emit('combat-update', {
+            type: 'state-sync',
+            combatActive: stateRef.current.combatState.active,
+            currentTurn: stateRef.current.combatState.currentTurn,
+            roundNumber: stateRef.current.combatState.roundNumber,
+            participants: stateRef.current.combatState.participants,
+          });
+        }
+        // Always send current ambient effect (even if "none")
+        socket.emit('ambient-effect', { effect: stateRef.current.ambientEffect });
       }
     });
 


### PR DESCRIPTION
## Summary
- **Fix Notion monster action parsing** - Properly parses continuous text, extracts saving throws, merges sub-attacks
- **Monster detail modal** - Changed from side panel to centered modal for better readability
- **Animation sync on player connect** - Players now see running animations when they connect

## Changes
- Improved action/traits parsing from Notion imports
- Updated monster detail view to centered modal in all components
- Fixed ambient effect sync when players join mid-animation

## Test plan
- [x] Sync monsters from Notion and verify actions display correctly
- [x] Click monster to verify centered modal appears
- [x] Start animation as DM, connect as player, verify animation visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)