### PR TITLE
feat: Display player combat stats for DM (#71)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -270,6 +270,13 @@ function CombatTrackerContent() {
             ac: number
             initiative: number
             conditions: string[]
+            passive_perception: number | null
+            strength: number | null
+            dexterity: number | null
+            constitution: number | null
+            intelligence: number | null
+            wisdom: number | null
+            charisma: number | null
           }) => ({
             id: c.id,
             name: c.name,
@@ -282,6 +289,13 @@ function CombatTrackerContent() {
             conditions: c.conditions || [],
             exhaustionLevel: 0,
             isConnected: false,
+            passivePerception: c.passive_perception,
+            strength: c.strength,
+            dexterity: c.dexterity,
+            constitution: c.constitution,
+            intelligence: c.intelligence,
+            wisdom: c.wisdom,
+            charisma: c.charisma,
           }))
           setPlayers(mappedCharacters)
           setAllCampaignCharacters(mappedCharacters)
@@ -423,6 +437,8 @@ function CombatTrackerContent() {
       player.characters.forEach((char, idx) => {
         const id = String(char.odNumber)
         connectedCharacterIds.add(id)
+        // Get static data from campaign characters (includes stats from Notion)
+        const campaignChar = allCampaignCharacters.find(c => c.id === id)
         connectedCharactersMap.set(id, {
           id,
           name: char.name,
@@ -439,6 +455,14 @@ function CombatTrackerContent() {
           playerSocketId: player.socketId,
           isFirstInGroup: idx === 0,
           groupSize: player.characters.length,
+          // Include stats from Notion (campaign characters)
+          passivePerception: campaignChar?.passivePerception,
+          strength: campaignChar?.strength,
+          dexterity: campaignChar?.dexterity,
+          constitution: campaignChar?.constitution,
+          intelligence: campaignChar?.intelligence,
+          wisdom: campaignChar?.wisdom,
+          charisma: campaignChar?.charisma,
         })
       })
     })

--- a/components/draggable-card.tsx
+++ b/components/draggable-card.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react"
 import { useDraggable } from "@dnd-kit/core"
 import { useSortable } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
-import { GripVertical, X, Plus, Wifi, WifiOff } from "lucide-react"
+import { GripVertical, X, Plus, Wifi, WifiOff, Eye } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -165,7 +165,7 @@ export function DraggablePlayerCard({ player, isInCombat, compact = false, onUpd
             )}
           </div>
           {!compact && (
-            <div className="flex items-center gap-2 mt-1">
+            <div className="flex items-center gap-2 mt-1 flex-wrap">
               <span className="text-xs text-muted-foreground">
                 {player.class} Niv.{player.level}
               </span>
@@ -175,6 +175,15 @@ export function DraggablePlayerCard({ player, isInCombat, compact = false, onUpd
               )}>
                 CA {player.ac}
               </Badge>
+              {player.passivePerception && (
+                <Badge variant="outline" className={cn(
+                  "text-xs px-1.5 py-0",
+                  isDisconnected ? "border-muted-foreground/30 text-muted-foreground" : "border-sky-500/30 text-sky-500"
+                )}>
+                  <Eye className="w-3 h-3 mr-1" />
+                  PP {player.passivePerception}
+                </Badge>
+              )}
             </div>
           )}
         </div>

--- a/components/player-panel.tsx
+++ b/components/player-panel.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { Users, ChevronDown, ChevronUp, Minus, Plus, GripVertical, Zap, UserPlus, Check, WifiOff, Wifi, HeartPulse } from "lucide-react"
+import { Users, ChevronDown, ChevronUp, Minus, Plus, GripVertical, Zap, UserPlus, Check, WifiOff, Wifi, HeartPulse, Eye } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -21,6 +21,12 @@ import { ConditionList } from "@/components/condition-badge"
 import { ConditionManager } from "@/components/condition-manager"
 
 const QUICK_HP_VALUES = [1, 3, 5, 10]
+
+function formatMod(score: number | null | undefined): string {
+  if (score == null) return "-"
+  const mod = Math.floor((score - 10) / 2)
+  return mod >= 0 ? `+${mod}` : `${mod}`
+}
 
 interface PlayerPanelProps {
   players: Character[]
@@ -155,6 +161,7 @@ export function PlayerPanel({ players, onUpdateHp, onUpdateInitiative, onUpdateC
                                   </div>
                                   <p className="text-xs text-muted-foreground">
                                     {player.class} Niv. {player.level} • CA {player.ac}
+                                    {player.passivePerception && ` • PP ${player.passivePerception}`}
                                   </p>
                                 </div>
                                 <Button
@@ -330,6 +337,12 @@ export function PlayerPanel({ players, onUpdateHp, onUpdateInitiative, onUpdateC
                         <Badge variant="outline" className="border-gold/50 text-gold">
                           CA {player.ac}
                         </Badge>
+                        {mode === "mj" && player.passivePerception && (
+                          <Badge variant="outline" className="border-sky-500/50 text-sky-500">
+                            <Eye className="w-3 h-3 mr-1" />
+                            PP {player.passivePerception}
+                          </Badge>
+                        )}
                         {/* Only show expand chevron for DM or player's own characters */}
                         {(mode === "mj" || ownCharacterIds.includes(player.id)) && (
                           expandedPlayer === player.id ? (
@@ -414,17 +427,38 @@ export function PlayerPanel({ players, onUpdateHp, onUpdateInitiative, onUpdateC
                         </div>
                       )}
 
-                      {/* Initiative */}
-                      <div className="mb-3">
-                        <label className="text-xs text-muted-foreground mb-1 block">Initiative</label>
-                        <Input
-                          type="number"
-                          value={player.initiative || ""}
-                          onChange={(e) => onUpdateInitiative(player.id, Number.parseInt(e.target.value) || 0)}
-                          className="min-h-[40px] text-sm bg-background"
-                          placeholder="0"
-                        />
-                      </div>
+                      {/* Combat Stats Section - DM Only */}
+                      {(player.passivePerception || player.strength) && (
+                        <div className="mb-3 p-2 bg-secondary/30 rounded-lg">
+                          <h4 className="text-xs text-muted-foreground mb-2 font-medium">Stats de combat</h4>
+
+                          {/* Passive Perception */}
+                          {player.passivePerception && (
+                            <div className="flex items-center gap-2 mb-2">
+                              <Eye className="w-4 h-4 text-gold" />
+                              <span className="text-sm">PP {player.passivePerception}</span>
+                            </div>
+                          )}
+
+                          {/* Ability Scores Grid */}
+                          <div className="grid grid-cols-6 gap-1 text-center text-xs">
+                            {[
+                              { label: "FOR", value: player.strength },
+                              { label: "DEX", value: player.dexterity },
+                              { label: "CON", value: player.constitution },
+                              { label: "INT", value: player.intelligence },
+                              { label: "SAG", value: player.wisdom },
+                              { label: "CHA", value: player.charisma },
+                            ].map((stat) => (
+                              <div key={stat.label} className="p-1 bg-background/50 rounded">
+                                <div className="text-muted-foreground">{stat.label}</div>
+                                <div className="font-medium">{stat.value ?? "-"}</div>
+                                <div className="text-gold text-xs">{formatMod(stat.value)}</div>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      )}
 
                       {/* Full HP Button */}
                       <Button

--- a/lib/notion.ts
+++ b/lib/notion.ts
@@ -503,6 +503,14 @@ export interface NotionCharacter {
   ac: number;
   initiative: number;
   conditions: string[];
+  // Combat stats
+  passive_perception: number | null;
+  strength: number | null;
+  dexterity: number | null;
+  constitution: number | null;
+  intelligence: number | null;
+  wisdom: number | null;
+  charisma: number | null;
 }
 
 /**
@@ -597,6 +605,18 @@ function mapNotionPageToCharacter(page: any): NotionCharacter | null {
     // AC is a number property
     const ac = extractNumber(props.CA?.number) ?? 10;
 
+    // Passive Perception - try both "PP" and "Perception Passive" property names
+    const passivePerception = extractNumber(props.PP?.number) ?? extractNumber(props['Perception Passive']?.number);
+
+    // Ability scores (same property names as monsters)
+    const strength = extractNumber(props.FOR?.number);
+    const dexterity = extractNumber(props.DEX?.number);
+    const constitution = extractNumber(props.CON?.number);
+    const intelligence = extractNumber(props.INT?.number);
+    const wisdom = extractNumber(props.SAG?.number);
+    // Try both "CHAR" and "CHA" for charisma
+    const charisma = extractNumber(props.CHAR?.number) ?? extractNumber(props.CHA?.number);
+
     return {
       id: page.id,
       name,
@@ -607,6 +627,13 @@ function mapNotionPageToCharacter(page: any): NotionCharacter | null {
       ac,
       initiative: 0,
       conditions: [],
+      passive_perception: passivePerception,
+      strength,
+      dexterity,
+      constitution,
+      intelligence,
+      wisdom,
+      charisma,
     };
   } catch (error) {
     console.error('Error mapping Notion character:', error);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -15,6 +15,14 @@ export interface Character {
   playerSocketId?: string
   isFirstInGroup?: boolean
   groupSize?: number
+  // Combat stats (synced from Notion)
+  passivePerception?: number | null
+  strength?: number | null
+  dexterity?: number | null
+  constitution?: number | null
+  intelligence?: number | null
+  wisdom?: number | null
+  charisma?: number | null
 }
 
 export interface Monster {


### PR DESCRIPTION
## Summary
- Add passive perception (PP) and ability scores display for DM
- Sync PP, FOR, DEX, CON, INT, SAG, CHA from Notion characters database
- Show PP badge on player cards (build and combat modes)
- Display full ability scores grid when expanding a player (DM only)
- Remove redundant initiative field from expanded view

## Test plan
- [ ] Login as DM
- [ ] Verify PP badge appears on player cards
- [ ] Click on a player to expand and verify ability scores grid shows
- [ ] Check all 6 stats (FOR, DEX, CON, INT, SAG, CHA) with modifiers

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)