### PR TITLE
feat: Implement XP summary modal with combat auto-end

### DIFF
--- a/components/xp-summary-modal.tsx
+++ b/components/xp-summary-modal.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { Trophy, Users, Scroll } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { ScrollArea } from '@/components/ui/scroll-area'
+
+interface KilledMonster {
+  name: string
+  xp: number
+}
+
+interface XpSummaryModalProps {
+  open: boolean
+  onClose: () => void
+  killedMonsters: KilledMonster[]
+  playerCount: number
+}
+
+export function XpSummaryModal({
+  open,
+  onClose,
+  killedMonsters,
+  playerCount,
+}: XpSummaryModalProps) {
+  const totalXp = killedMonsters.reduce((sum, m) => sum + m.xp, 0)
+  const perPlayerXp = playerCount > 0 ? Math.floor(totalXp / playerCount) : totalXp
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <DialogContent className="sm:max-w-md bg-slate-900 border-gold/30">
+        <DialogHeader>
+          <DialogTitle className="text-2xl text-center text-gold flex items-center justify-center gap-2">
+            <Trophy className="w-6 h-6" />
+            Combat terminé !
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-6 py-4">
+          {/* Total XP */}
+          <div className="text-center">
+            <div className="text-4xl font-bold text-gold">
+              {totalXp.toLocaleString()} XP
+            </div>
+            <div className="text-sm text-muted-foreground mt-1">XP Total gagné</div>
+          </div>
+
+          {/* Per Player XP */}
+          {playerCount > 1 && (
+            <div className="flex items-center justify-center gap-2 text-lg bg-slate-800/50 rounded-lg p-3">
+              <Users className="w-5 h-5 text-blue-400" />
+              <span className="text-blue-400 font-semibold">
+                {perPlayerXp.toLocaleString()} XP
+              </span>
+              <span className="text-muted-foreground">
+                par joueur ({playerCount} joueurs)
+              </span>
+            </div>
+          )}
+
+          {/* Killed Monsters List */}
+          {killedMonsters.length > 0 && (
+            <div className="space-y-2">
+              <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+                <Scroll className="w-4 h-4" />
+                Monstres vaincus
+              </div>
+              <ScrollArea className="max-h-48">
+                <div className="space-y-1">
+                  {killedMonsters.map((monster, index) => (
+                    <div
+                      key={`${monster.name}-${index}`}
+                      className="flex justify-between items-center py-1.5 px-3 bg-slate-800/30 rounded text-sm"
+                    >
+                      <span className="text-slate-200">{monster.name}</span>
+                      <span className="text-gold font-medium">
+                        {monster.xp > 0 ? `${monster.xp.toLocaleString()} XP` : '-'}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </ScrollArea>
+            </div>
+          )}
+
+          {killedMonsters.length === 0 && (
+            <div className="text-center text-muted-foreground text-sm py-4">
+              Aucun monstre vaincu
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            onClick={onClose}
+            className="w-full bg-gold hover:bg-gold/80 text-slate-900 font-semibold"
+          >
+            Fermer
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/lib/socket-context/reducer.ts
+++ b/lib/socket-context/reducer.ts
@@ -260,8 +260,29 @@ export function socketReducer(state: SocketState, action: SocketAction): SocketS
         };
       }
 
+      // XP summary when combat ends (for players to show modal)
+      if (data.type === 'combat_end_xp' && data.xpSummary) {
+        return {
+          ...state,
+          xpSummary: data.xpSummary,
+        };
+      }
+
       return state;
     }
+
+    // XP Summary
+    case 'SET_XP_SUMMARY':
+      return {
+        ...state,
+        xpSummary: action.xpSummary,
+      };
+
+    case 'CLEAR_XP_SUMMARY':
+      return {
+        ...state,
+        xpSummary: null,
+      };
 
     case 'HP_CHANGE': {
       const { participantId, participantType, newHp } = action;

--- a/lib/socket-context/types.ts
+++ b/lib/socket-context/types.ts
@@ -71,6 +71,14 @@ export interface SocketState {
   // DM disconnect tracking (for player overlay)
   dmDisconnected: boolean;
   dmDisconnectTime: number | null;
+
+  // XP Summary (shown when combat ends)
+  xpSummary: {
+    totalXp: number;
+    perPlayerXp: number;
+    playerCount: number;
+    killedMonsters: { name: string; xp: number }[];
+  } | null;
 }
 
 // Action types
@@ -119,7 +127,11 @@ export type SocketAction =
 
   // DM disconnect/reconnect
   | { type: 'DM_DISCONNECTED'; timestamp: number }
-  | { type: 'DM_RECONNECTED' };
+  | { type: 'DM_RECONNECTED' }
+
+  // XP Summary
+  | { type: 'SET_XP_SUMMARY'; xpSummary: SocketState['xpSummary'] }
+  | { type: 'CLEAR_XP_SUMMARY' };
 
 // Initial state
 export const initialSocketState: SocketState = {
@@ -161,6 +173,9 @@ export const initialSocketState: SocketState = {
   // DM disconnect tracking
   dmDisconnected: false,
   dmDisconnectTime: null,
+
+  // XP Summary
+  xpSummary: null,
 };
 
 // Join campaign data

--- a/lib/socket-events.ts
+++ b/lib/socket-events.ts
@@ -49,11 +49,17 @@ export interface ConnectedPlayersData {
 }
 
 export interface CombatUpdateData {
-  type: 'start' | 'stop' | 'next-turn' | 'state-sync';
+  type: 'start' | 'stop' | 'next-turn' | 'state-sync' | 'combat_end_xp';
   combatActive: boolean;
   currentTurn: number;
   roundNumber?: number;
   participants?: CombatParticipantData[];
+  xpSummary?: {
+    totalXp: number;
+    perPlayerXp: number;
+    playerCount: number;
+    killedMonsters: { name: string; xp: number }[];
+  };
 }
 
 export interface HpChangeData {

--- a/server.ts
+++ b/server.ts
@@ -75,11 +75,17 @@ interface JoinCampaignData {
 }
 
 interface CombatUpdateData {
-  type: 'start' | 'stop' | 'next-turn' | 'state-sync';
+  type: 'start' | 'stop' | 'next-turn' | 'state-sync' | 'combat_end_xp';
   combatActive: boolean;
   currentTurn: number;
   roundNumber?: number;
   participants?: unknown[];
+  xpSummary?: {
+    totalXp: number;
+    perPlayerXp: number;
+    playerCount: number;
+    killedMonsters: { name: string; xp: number }[];
+  };
 }
 
 interface HpChangeData {


### PR DESCRIPTION
## Summary

This pull request implements a comprehensive XP summary feature that enhances the end-of-combat experience:

- **XP Summary Modal**: New component that displays total XP gained, per-player breakdown, and list of defeated monsters
- **Combat Auto-End**: Combat automatically ends when all monsters reach 0 HP (DM only)
- **Real-time Sync**: XP summary is synced via WebSocket so all players see the modal when the DM ends combat
- **Improved UX**: Players get immediate visual feedback on their earned XP and defeated enemies

## Changes Made

**New Files:**
- `components/xp-summary-modal.tsx` - XP summary modal component with trophy icon and monster list

**Modified Files:**
- `app/page.tsx` - Added XP state management, auto-end detection, and modal display logic
- `lib/socket-context/types.ts` - Added xpSummary state type with killedMonsters and playerCount
- `lib/socket-context/reducer.ts` - Handle XP summary state updates and clearing
- `lib/socket-events.ts` - Added combat_end_xp event type
- `server.ts` - Updated to handle combat_end_xp WebSocket events

## Test Plan

- [ ] Start a combat as DM
- [ ] Kill all monsters and verify combat auto-ends
- [ ] Check that XP modal appears showing total and per-player XP
- [ ] Verify monster list displays with correct XP values
- [ ] As a player, verify you receive and see the XP summary modal when DM ends combat
- [ ] Test with multiple players to verify per-player XP calculation
- [ ] Verify modal closes properly when clicking "Fermer" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)