### PR TITLE
feat: Fix XP reading from Notion and improve monster data management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,17 @@ docker-compose up --build
 
 Both environments can run in parallel thanks to different ports.
 
+### Synology Production Server
+- **IP**: 192.168.1.2
+- **SSH User**: mathieu
+- **SSH Key**: Available locally
+- **Docker path**: Uses `docker-compose.synology.yml`
+
+To connect:
+```bash
+ssh mathieu@192.168.1.2
+```
+
 ## Commands (inside container)
 
 ```bash

--- a/lib/notion.ts
+++ b/lib/notion.ts
@@ -430,7 +430,7 @@ export function mapNotionMonsterToDbMonster(notionMonster: any): Partial<Monster
   // Other properties
   const creature_type = extractSelect(props.Race) || extractText(props.Race?.rich_text || []);
   const size = extractSelect(props.Taille) || extractText(props.Taille?.rich_text || []);
-  const challenge_rating_xp = extractNumber(props['Puissance (XP)']?.number);
+  const challenge_rating_xp = extractNumber(props.XP?.number);
 
   // Read separate trait columns (comma-separated text)
   const skillsText = extractText(props.Compétences?.rich_text || []);


### PR DESCRIPTION
## Summary

- Fix XP reading from correct Notion property 'XP' instead of 'Puissance (XP)' - resolves 0 XP display in combat end modal and difficulty calculator
- Add auto-refresh for monster list after Notion sync
- Fix monster data mapping from Notion and enhance display  
- Add responsive mobile layouts and level sync improvements
- Add inventory manager with direct item selection from catalog
- New migrations for monster database enhancements

## Test plan

- [ ] Verify XP displays correctly in combat end modal (should read from 'XP' property)
- [ ] Verify difficulty calculator uses correct XP values
- [ ] Test monster list auto-refresh after Notion sync
- [ ] Verify monster data displays correctly after sync
- [ ] Test responsive layouts on mobile devices
- [ ] Test inventory manager item selection

🧠 Generated with [Claude Code](https://claude.com/claude-code)