### PR TITLE
fix: Make monster picker cards responsive with two-row layout

### DIFF
--- a/components/monster-picker-panel.tsx
+++ b/components/monster-picker-panel.tsx
@@ -53,15 +53,15 @@ function DraggableDbMonsterCard({ monster, onAddClick, onViewClick }: DraggableD
         !isMobileDevice && "touch-none cursor-grab active:cursor-grabbing"
       )}
     >
-      <div className="flex items-center gap-2">
-        {/* Drag Handle - visible on hover, hidden on mobile */}
-        <div className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity hidden md:block">
-          <GripVertical className="w-4 h-4 text-muted-foreground" />
-        </div>
-
-        {/* Monster Info */}
-        <div className="flex items-center gap-2 flex-1 min-w-0">
-          {/* Hide image on mobile to save space */}
+      {/* Two-row layout for guaranteed fit on all screen widths */}
+      <div className="flex flex-col gap-1.5">
+        {/* Row 1: Name */}
+        <div className="flex items-center gap-2">
+          {/* Drag Handle - visible on hover, hidden on mobile */}
+          <div className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity hidden md:block">
+            <GripVertical className="w-4 h-4 text-muted-foreground" />
+          </div>
+          {/* Image - hidden on mobile */}
           {monster.image_url && (
             <div className="w-8 h-8 rounded overflow-hidden border border-border shrink-0 hidden sm:block">
               {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -72,40 +72,39 @@ function DraggableDbMonsterCard({ monster, onAddClick, onViewClick }: DraggableD
               />
             </div>
           )}
-          <div className="min-w-0 flex-1">
-            <div className="font-medium text-sm truncate">{monster.name}</div>
-            <div className="text-xs text-muted-foreground truncate">
-              {monster.creature_type}
-            </div>
-          </div>
+          <h3 className="font-medium text-sm truncate flex-1 min-w-0">{monster.name}</h3>
         </div>
-
-        {/* Stats and Action Buttons */}
-        <div className="flex items-center gap-1 shrink-0 ml-auto">
-          <Badge variant="outline" className="text-xs border-crimson/30 text-crimson whitespace-nowrap">
-            PV {monster.hit_points}
-          </Badge>
-          <Button
-            size="icon"
-            variant="ghost"
-            className="h-7 w-7 sm:h-8 sm:w-8 text-muted-foreground hover:text-foreground hover:bg-secondary"
-            onClick={(e) => {
-              e.stopPropagation()
-              onViewClick(monster)
-            }}
-          >
-            <Eye className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
-          </Button>
-          <Button
-            size="icon"
-            className="h-7 w-7 sm:h-9 sm:w-9 bg-crimson hover:bg-crimson/80 text-white"
-            onClick={(e) => {
-              e.stopPropagation()
-              onAddClick(monster, e)
-            }}
-          >
-            <Plus className="w-4 h-4 sm:w-5 sm:h-5" />
-          </Button>
+        {/* Row 2: Type + PV + Action Buttons */}
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-xs text-muted-foreground truncate flex-1 min-w-0">
+            {monster.creature_type}
+            <Badge variant="outline" className="text-xs border-crimson/30 text-crimson ml-2">
+              PV {monster.hit_points}
+            </Badge>
+          </p>
+          <div className="flex items-center gap-1.5 shrink-0">
+            <Button
+              size="icon"
+              variant="ghost"
+              className="h-8 w-8 text-muted-foreground hover:text-foreground hover:bg-secondary"
+              onClick={(e) => {
+                e.stopPropagation()
+                onViewClick(monster)
+              }}
+            >
+              <Eye className="w-4 h-4" />
+            </Button>
+            <Button
+              size="icon"
+              className="h-8 w-8 bg-crimson hover:bg-crimson/80 text-white"
+              onClick={(e) => {
+                e.stopPropagation()
+                onAddClick(monster, e)
+              }}
+            >
+              <Plus className="w-4 h-4" />
+            </Button>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Restructure monster cards to use two-row layout like player panel
- Row 1: Monster name
- Row 2: Type + PV badge + Eye & Plus buttons
- Ensures all buttons are visible on any screen size

Generated with Claude Code