### PR TITLE
feat: Implement temporary hit points system and fix player default tab

### DIFF
--- a/app/api/characters/[characterId]/hp/route.ts
+++ b/app/api/characters/[characterId]/hp/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import pool from '@/lib/db';
 
 // GET /api/characters/[characterId]/hp
-// Returns HP, exhaustion, conditions, conditionDurations, and buffs (full status)
+// Returns HP, tempHp, exhaustion, conditions, conditionDurations, and buffs (full status)
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ characterId: string }> }
@@ -11,7 +11,7 @@ export async function GET(
     const { characterId } = await params;
 
     const result = await pool.query(
-      'SELECT current_hp, exhaustion_level, conditions, condition_durations, buffs FROM character_hp WHERE character_id = $1',
+      'SELECT current_hp, temp_hp, exhaustion_level, conditions, condition_durations, buffs FROM character_hp WHERE character_id = $1',
       [characterId]
     );
 
@@ -19,6 +19,7 @@ export async function GET(
       // No status found, return nulls (use defaults from Notion)
       return NextResponse.json({
         currentHp: null,
+        tempHp: null,
         exhaustionLevel: null,
         conditions: null,
         conditionDurations: null,
@@ -29,6 +30,7 @@ export async function GET(
     const row = result.rows[0];
     return NextResponse.json({
       currentHp: row.current_hp,
+      tempHp: row.temp_hp ?? null,
       exhaustionLevel: row.exhaustion_level ?? null,
       conditions: row.conditions ?? null,
       conditionDurations: row.condition_durations ?? null,
@@ -44,16 +46,16 @@ export async function GET(
 }
 
 // PUT /api/characters/[characterId]/hp
-// Saves HP, and optionally exhaustion, conditions, conditionDurations, and buffs
+// Saves HP, tempHp, and optionally exhaustion, conditions, conditionDurations, and buffs
 export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ characterId: string }> }
 ) {
   try {
     const { characterId } = await params;
-    const { currentHp, exhaustionLevel, conditions, conditionDurations, buffs, campaignId = 1 } = await request.json();
+    const { currentHp, tempHp, exhaustionLevel, conditions, conditionDurations, buffs, campaignId = 1 } = await request.json();
 
-    console.log('[HP API] PUT request for', characterId, '- conditionDurations:', conditionDurations);
+    console.log('[HP API] PUT request for', characterId, '- tempHp:', tempHp, '- conditionDurations:', conditionDurations);
 
     // Check if row exists
     const existing = await pool.query(
@@ -68,12 +70,13 @@ export async function PUT(
         // Cannot create without HP, but save exhaustion/conditions/buffs anyway
         // by first creating with a placeholder HP of 0
         result = await pool.query(
-          `INSERT INTO character_hp (character_id, campaign_id, current_hp, exhaustion_level, conditions, condition_durations, buffs, updated_at)
-           VALUES ($1, $2, 0, $3, $4, $5, $6, CURRENT_TIMESTAMP)
-           RETURNING current_hp, exhaustion_level, conditions, condition_durations, buffs`,
+          `INSERT INTO character_hp (character_id, campaign_id, current_hp, temp_hp, exhaustion_level, conditions, condition_durations, buffs, updated_at)
+           VALUES ($1, $2, 0, $3, $4, $5, $6, $7, CURRENT_TIMESTAMP)
+           RETURNING current_hp, temp_hp, exhaustion_level, conditions, condition_durations, buffs`,
           [
             characterId,
             campaignId,
+            tempHp ?? 0,
             exhaustionLevel ?? 0,
             conditions ? JSON.stringify(conditions) : '[]',
             conditionDurations ? JSON.stringify(conditionDurations) : '{}',
@@ -82,13 +85,14 @@ export async function PUT(
         );
       } else {
         result = await pool.query(
-          `INSERT INTO character_hp (character_id, campaign_id, current_hp, exhaustion_level, conditions, condition_durations, buffs, updated_at)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, CURRENT_TIMESTAMP)
-           RETURNING current_hp, exhaustion_level, conditions, condition_durations, buffs`,
+          `INSERT INTO character_hp (character_id, campaign_id, current_hp, temp_hp, exhaustion_level, conditions, condition_durations, buffs, updated_at)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, CURRENT_TIMESTAMP)
+           RETURNING current_hp, temp_hp, exhaustion_level, conditions, condition_durations, buffs`,
           [
             characterId,
             campaignId,
             currentHp,
+            tempHp ?? 0,
             exhaustionLevel ?? 0,
             conditions ? JSON.stringify(conditions) : '[]',
             conditionDurations ? JSON.stringify(conditionDurations) : '{}',
@@ -105,6 +109,10 @@ export async function PUT(
       if (currentHp !== undefined && currentHp !== null) {
         updates.push(`current_hp = $${paramIndex++}`);
         values.push(currentHp);
+      }
+      if (tempHp !== undefined) {
+        updates.push(`temp_hp = $${paramIndex++}`);
+        values.push(tempHp ?? 0);
       }
       if (exhaustionLevel !== undefined && exhaustionLevel !== null) {
         updates.push(`exhaustion_level = $${paramIndex++}`);
@@ -131,7 +139,7 @@ export async function PUT(
       result = await pool.query(
         `UPDATE character_hp SET ${updates.join(', ')}
          WHERE character_id = $${paramIndex++} AND campaign_id = $${paramIndex}
-         RETURNING current_hp, exhaustion_level, conditions, condition_durations, buffs`,
+         RETURNING current_hp, temp_hp, exhaustion_level, conditions, condition_durations, buffs`,
         values
       );
     }
@@ -139,6 +147,7 @@ export async function PUT(
     const row = result.rows[0];
     return NextResponse.json({
       currentHp: row.current_hp,
+      tempHp: row.temp_hp,
       exhaustionLevel: row.exhaustion_level,
       conditions: row.conditions,
       conditionDurations: row.condition_durations,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -285,9 +285,10 @@ function CombatTrackerContent() {
     }
   }
 
-  // Load status (HP, exhaustion, conditions, conditionDurations, buffs) from database for a character
+  // Load status (HP, tempHp, exhaustion, conditions, conditionDurations, buffs) from database for a character
   interface CharacterStatus {
     currentHp: number | null
+    tempHp: number | null
     exhaustionLevel: number | null
     conditions: string[] | null
     conditionDurations: Record<string, number> | null
@@ -301,6 +302,7 @@ function CombatTrackerContent() {
         console.log('[Status] Loaded from database:', characterId, data)
         return {
           currentHp: data.currentHp ?? null,
+          tempHp: data.tempHp ?? null,
           exhaustionLevel: data.exhaustionLevel ?? null,
           conditions: data.conditions ?? null,
           conditionDurations: data.conditionDurations ?? null,
@@ -310,7 +312,7 @@ function CombatTrackerContent() {
     } catch (error) {
       console.error('Failed to load status for character:', characterId, error)
     }
-    return { currentHp: null, exhaustionLevel: null, conditions: null, conditionDurations: null, buffs: null }
+    return { currentHp: null, tempHp: null, exhaustionLevel: null, conditions: null, conditionDurations: null, buffs: null }
   }
 
   // Load inventory from database for a character
@@ -353,6 +355,7 @@ function CombatTrackerContent() {
             class: char.class,
             level: char.level,
             currentHp: persistedStatus.currentHp ?? char.current_hp,
+            tempHp: persistedStatus.tempHp ?? undefined,
             maxHp: char.max_hp,
             ac: char.ac,
             initiative: char.initiative,
@@ -426,6 +429,7 @@ function CombatTrackerContent() {
                 level: c.level,
                 // Use persisted values if available, otherwise use Notion values
                 currentHp: persistedStatus.currentHp ?? c.current_hp,
+                tempHp: persistedStatus.tempHp ?? undefined,
                 maxHp: c.max_hp,
                 ac: c.ac,
                 initiative: c.initiative,
@@ -692,6 +696,8 @@ function CombatTrackerContent() {
           // HP: combat participant during combat, otherwise from connectedPlayers socket state
           currentHp: combatParticipant?.currentHp ?? char.currentHp,
           maxHp: char.maxHp,
+          // Temp HP: combat participant during combat, otherwise from connectedPlayers socket state
+          tempHp: combatParticipant?.tempHp ?? char.tempHp,
           ac: char.ac,
           // Use initiative override if set, otherwise use character's initiative
           initiative: playerInitiatives[id] ?? char.initiative,
@@ -731,6 +737,8 @@ function CombatTrackerContent() {
           ...connectedChar,
           // HP from socket is source of truth for connected players (synced via hp-change events)
           currentHp: connectedChar.currentHp,
+          // Temp HP from socket is source of truth for connected players
+          tempHp: connectedChar.tempHp ?? localPlayer?.tempHp,
           // CRITICAL: Use local inventory if player is in local state (it has the latest changes)
           inventory: localPlayer ? localPlayer.inventory : connectedChar.inventory,
           // Socket state (connectedChar) is source of truth for conditions - it's updated via condition-change events
@@ -755,6 +763,8 @@ function CombatTrackerContent() {
         initiative: playerInitiatives[char.id] ?? char.initiative,
         // Combat participant is source of truth during combat
         currentHp: combatParticipant?.currentHp ?? localPlayer?.currentHp ?? char.currentHp,
+        // Temp HP from combat participant during combat, otherwise from local state
+        tempHp: combatParticipant?.tempHp ?? localPlayer?.tempHp ?? char.tempHp,
         conditions: combatParticipant?.conditions ?? char.conditions ?? [],
         conditionDurations: combatParticipant?.conditionDurations ?? localPlayer?.conditionDurations ?? char.conditionDurations ?? {},
         exhaustionLevel: combatParticipant?.exhaustionLevel ?? char.exhaustionLevel ?? 0,
@@ -1145,7 +1155,29 @@ function CombatTrackerContent() {
       }
     }
 
-    const newHp = Math.max(0, Math.min(player.maxHp, player.currentHp + change))
+    // Handle temp HP absorption for damage (D&D 5e rules)
+    let actualHpChange = change
+    let newTempHp = player.tempHp ?? 0
+
+    if (change < 0 && newTempHp > 0) {
+      // Damage is dealt and player has temp HP
+      const damage = Math.abs(change)
+      if (damage <= newTempHp) {
+        // Temp HP absorbs all damage
+        newTempHp -= damage
+        actualHpChange = 0 // No damage to regular HP
+      } else {
+        // Temp HP absorbs part of damage, rest goes to regular HP
+        actualHpChange = -(damage - newTempHp) // Remaining damage as negative
+        newTempHp = 0 // Temp HP depleted
+      }
+    }
+
+    // Remove temp HP completely when it reaches 0
+    // Use 0 instead of undefined so it serializes over socket and clears temp HP
+    const finalTempHp = newTempHp > 0 ? newTempHp : 0
+
+    const newHp = Math.max(0, Math.min(player.maxHp, player.currentHp + actualHpChange))
     const wasAtZeroHp = player.currentHp === 0
 
     // Add history entry for damage/heal
@@ -1161,13 +1193,15 @@ function CombatTrackerContent() {
     }
 
     // Update locally first for immediate feedback
+    // For local state, use undefined when tempHp is 0 (cleaner display)
+    const localTempHp = finalTempHp > 0 ? finalTempHp : undefined
     setPlayers((prev) => {
       const exists = prev.some(p => p.id === id)
       if (exists) {
-        return prev.map((p) => (p.id === id ? { ...p, currentHp: newHp } : p))
+        return prev.map((p) => (p.id === id ? { ...p, currentHp: newHp, tempHp: localTempHp } : p))
       } else {
         // Add player to state with updated HP (player was not in local state yet)
-        return [...prev, { ...player, currentHp: newHp }]
+        return [...prev, { ...player, currentHp: newHp, tempHp: localTempHp }]
       }
     })
 
@@ -1176,13 +1210,14 @@ function CombatTrackerContent() {
       participantId: id,
       participantType: 'player',
       newHp,
+      tempHp: finalTempHp,
       change,
       source: mode === 'mj' ? 'dm' : 'player',
     })
 
     if (combatActive) {
       setCombatParticipants((prev) =>
-        prev.map((p) => (p.id === id ? { ...p, currentHp: newHp } : p)),
+        prev.map((p) => (p.id === id ? { ...p, currentHp: newHp, tempHp: localTempHp } : p)),
       )
 
       // Reset death saves when healed from 0 HP
@@ -1191,15 +1226,61 @@ function CombatTrackerContent() {
       }
     }
 
-    // Persist HP to database for session persistence
+    // Persist HP and temp HP to database for session persistence
     try {
       await fetch(`/api/characters/${id}/hp`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ currentHp: newHp }),
+        body: JSON.stringify({ currentHp: newHp, tempHp: finalTempHp ?? 0 }),
       })
     } catch (error) {
       console.error('Failed to persist HP:', error)
+    }
+  }
+
+  // Set temp HP for a player (D&D 5e: replaces existing temp HP, cannot stack)
+  const updatePlayerTempHp = async (id: string, newTempHp: number) => {
+    const player = displayPlayers.find(p => p.id === id)
+    if (!player) return
+
+    // Temp HP cannot be negative
+    const finalTempHp = Math.max(0, newTempHp) || undefined
+
+    // Update locally
+    setPlayers((prev) => {
+      const exists = prev.some(p => p.id === id)
+      if (exists) {
+        return prev.map((p) => (p.id === id ? { ...p, tempHp: finalTempHp } : p))
+      } else {
+        return [...prev, { ...player, tempHp: finalTempHp }]
+      }
+    })
+
+    // Emit to sync with other clients
+    emitHpChange({
+      participantId: id,
+      participantType: 'player',
+      newHp: player.currentHp,
+      tempHp: finalTempHp,
+      change: 0,
+      source: 'dm',
+    })
+
+    if (combatActive) {
+      setCombatParticipants((prev) =>
+        prev.map((p) => (p.id === id ? { ...p, tempHp: finalTempHp } : p)),
+      )
+    }
+
+    // Persist to database
+    try {
+      await fetch(`/api/characters/${id}/hp`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tempHp: finalTempHp ?? 0 }),
+      })
+    } catch (error) {
+      console.error('Failed to persist temp HP:', error)
     }
   }
 
@@ -1708,6 +1789,7 @@ function CombatTrackerContent() {
       // Use current HP (persisted in session) instead of resetting to max
       currentHp: player.currentHp,
       maxHp: player.maxHp,
+      tempHp: player.tempHp,  // Keep current temp HP
       conditions: player.conditions || [],  // Keep current conditions
       conditionDurations: player.conditionDurations || {},  // Keep current condition durations
       exhaustionLevel: player.exhaustionLevel || 0,  // Keep current exhaustion
@@ -2258,6 +2340,10 @@ function CombatTrackerContent() {
                     if (type === "player") updatePlayerHp(id, change)
                     else updateMonsterHp(id, change)
                   } : undefined}
+                  onUpdateTempHp={mode === "mj" ? (id, tempHp, type) => {
+                    if (type === "player") updatePlayerTempHp(id, tempHp)
+                    // Note: monsters don't have temp HP in this implementation
+                  } : undefined}
                   onUpdateConditions={mode === "mj" ? (id, conditions, type, conditionDurations) => {
                     if (type === "player") updatePlayerConditions(id, conditions, conditionDurations)
                     else updateMonsterConditions(id, conditions, conditionDurations)
@@ -2365,6 +2451,10 @@ function CombatTrackerContent() {
                     onUpdateHp={mode === "mj" ? (id, change, type) => {
                       if (type === "player") updatePlayerHp(id, change)
                       else updateMonsterHp(id, change)
+                    } : undefined}
+                    onUpdateTempHp={mode === "mj" ? (id, tempHp, type) => {
+                      if (type === "player") updatePlayerTempHp(id, tempHp)
+                      // Note: monsters don't have temp HP in this implementation
                     } : undefined}
                     onUpdateConditions={mode === "mj" ? (id, conditions, type, conditionDurations) => {
                       if (type === "player") updatePlayerConditions(id, conditions, conditionDurations)

--- a/components/combat-panel.tsx
+++ b/components/combat-panel.tsx
@@ -41,6 +41,7 @@ interface CombatPanelProps {
   onNextTurn?: () => void
   onClearCombat?: () => void
   onUpdateHp?: (id: string, change: number, type: "player" | "monster") => void
+  onUpdateTempHp?: (id: string, tempHp: number, type: "player" | "monster") => void
   onUpdateConditions?: (id: string, conditions: string[], type: "player" | "monster", conditionDurations?: Record<string, number>) => void
   onUpdateExhaustion?: (id: string, level: number, type: "player" | "monster") => void
   onUpdateBuffs?: (id: string, buffs: ActiveBuff[], type: "player" | "monster") => void
@@ -62,6 +63,7 @@ export function CombatPanel({
   onNextTurn,
   onClearCombat,
   onUpdateHp,
+  onUpdateTempHp,
   onUpdateConditions,
   onUpdateExhaustion,
   onUpdateBuffs,
@@ -75,6 +77,7 @@ export function CombatPanel({
   const [selectedParticipant, setSelectedParticipant] = useState<CombatParticipant | null>(null)
   const [petDialogOwner, setPetDialogOwner] = useState<CombatParticipant | null>(null)
   const [hpAmount, setHpAmount] = useState("")
+  const [tempHpAmount, setTempHpAmount] = useState("")
   const [editingNameId, setEditingNameId] = useState<string | null>(null)
   const [editingNameValue, setEditingNameValue] = useState("")
   const [selectedMonsterDetail, setSelectedMonsterDetail] = useState<DbMonster | null>(null)
@@ -390,8 +393,23 @@ export function CombatPanel({
                               )}
                             >
                               {participant.currentHp} / {participant.maxHp}
+                              {participant.tempHp && participant.tempHp > 0 && (
+                                <span className="text-blue-400 ml-1">(+{participant.tempHp})</span>
+                              )}
                             </span>
                           </div>
+                          {/* Temp HP Bar (blue) - shown above regular HP bar */}
+                          {participant.tempHp && participant.tempHp > 0 && (
+                            <div className="h-1.5 bg-muted rounded-full overflow-hidden mb-0.5">
+                              <div
+                                className="h-full bg-blue-500 transition-all duration-500 ease-out"
+                                style={{
+                                  width: `${Math.min(100, (participant.tempHp / participant.maxHp) * 100)}%`,
+                                }}
+                              />
+                            </div>
+                          )}
+                          {/* Regular HP Bar */}
                           <div className="h-2 bg-muted rounded-full overflow-hidden">
                             <div
                               className={cn(
@@ -522,7 +540,7 @@ export function CombatPanel({
                                   PV
                                 </Button>
                               </DialogTrigger>
-                              <DialogContent className="bg-card border-border max-w-[calc(100vw-2rem)]">
+                              <DialogContent className="bg-card border-border max-w-[calc(100vw-2rem)] max-h-[85vh] overflow-y-auto">
                                 <DialogHeader>
                                   <DialogTitle className="text-gold">{participant.name}</DialogTitle>
                                 </DialogHeader>
@@ -599,6 +617,57 @@ export function CombatPanel({
                                       </Button>
                                     </div>
                                   </div>
+                                  {/* Temp HP Section - Players only */}
+                                  {participant.type === "player" && onUpdateTempHp && (
+                                    <div className="border-t border-border pt-4">
+                                      <label className="text-sm text-blue-400 mb-2 block font-medium">
+                                        <Shield className="w-4 h-4 inline mr-1" />
+                                        PV Temporaires
+                                        {participant.tempHp && participant.tempHp > 0 && (
+                                          <span className="text-muted-foreground ml-2">
+                                            (actuel: {participant.tempHp})
+                                          </span>
+                                        )}
+                                      </label>
+                                      <div className="flex gap-2">
+                                        <Input
+                                          type="number"
+                                          value={tempHpAmount}
+                                          onChange={(e) => setTempHpAmount(e.target.value)}
+                                          placeholder="Montant..."
+                                          className="bg-background min-h-[44px]"
+                                          min="0"
+                                        />
+                                        <Button
+                                          onClick={() => {
+                                            const amount = parseInt(tempHpAmount, 10)
+                                            if (!isNaN(amount) && amount >= 0) {
+                                              onUpdateTempHp(participant.id, amount, participant.type)
+                                              setTempHpAmount("")
+                                            }
+                                          }}
+                                          disabled={!tempHpAmount || parseInt(tempHpAmount, 10) < 0}
+                                          className="shrink-0 min-h-[44px] bg-blue-500 hover:bg-blue-600 text-white active:scale-95 disabled:opacity-50"
+                                        >
+                                          Appliquer
+                                        </Button>
+                                        {participant.tempHp && participant.tempHp > 0 && (
+                                          <Button
+                                            onClick={() => {
+                                              onUpdateTempHp(participant.id, 0, participant.type)
+                                            }}
+                                            variant="outline"
+                                            className="shrink-0 min-h-[44px] border-blue-500/30 text-blue-400 hover:bg-blue-500/10 active:scale-95"
+                                          >
+                                            Retirer
+                                          </Button>
+                                        )}
+                                      </div>
+                                      <p className="text-xs text-muted-foreground mt-2">
+                                        Les PV temporaires absorbent les dégâts en premier et ne se cumulent pas.
+                                      </p>
+                                    </div>
+                                  )}
                                 </div>
                               </DialogContent>
                             </Dialog>
@@ -793,8 +862,23 @@ export function CombatPanel({
                               )}
                             >
                               {participant.currentHp} / {participant.maxHp}
+                              {participant.tempHp && participant.tempHp > 0 && (
+                                <span className="text-blue-400 ml-1">(+{participant.tempHp})</span>
+                              )}
                             </span>
                           </div>
+                          {/* Temp HP Bar (blue) - shown above regular HP bar */}
+                          {participant.tempHp && participant.tempHp > 0 && (
+                            <div className="h-1.5 bg-muted rounded-full overflow-hidden mb-0.5">
+                              <div
+                                className="h-full bg-blue-500 transition-all duration-500 ease-out"
+                                style={{
+                                  width: `${Math.min(100, (participant.tempHp / participant.maxHp) * 100)}%`,
+                                }}
+                              />
+                            </div>
+                          )}
+                          {/* Regular HP Bar */}
                           <div className="h-2.5 bg-muted rounded-full overflow-hidden">
                             <div
                               className={cn(
@@ -1027,7 +1111,7 @@ export function CombatPanel({
                               PV
                             </Button>
                           </DialogTrigger>
-                          <DialogContent className="bg-card border-border max-w-[calc(100vw-2rem)]">
+                          <DialogContent className="bg-card border-border max-w-[calc(100vw-2rem)] max-h-[85vh] overflow-y-auto">
                             <DialogHeader>
                               <DialogTitle className="text-gold">{participant.name}</DialogTitle>
                             </DialogHeader>
@@ -1104,6 +1188,57 @@ export function CombatPanel({
                                   </Button>
                                 </div>
                               </div>
+                              {/* Temp HP Section - Players only (Desktop view) */}
+                              {participant.type === "player" && onUpdateTempHp && (
+                                <div className="border-t border-border pt-4">
+                                  <label className="text-sm text-blue-400 mb-2 block font-medium">
+                                    <Shield className="w-4 h-4 inline mr-1" />
+                                    PV Temporaires
+                                    {participant.tempHp && participant.tempHp > 0 && (
+                                      <span className="text-muted-foreground ml-2">
+                                        (actuel: {participant.tempHp})
+                                      </span>
+                                    )}
+                                  </label>
+                                  <div className="flex gap-2">
+                                    <Input
+                                      type="number"
+                                      value={tempHpAmount}
+                                      onChange={(e) => setTempHpAmount(e.target.value)}
+                                      placeholder="Montant..."
+                                      className="bg-background min-h-[44px]"
+                                      min="0"
+                                    />
+                                    <Button
+                                      onClick={() => {
+                                        const amount = parseInt(tempHpAmount, 10)
+                                        if (!isNaN(amount) && amount >= 0) {
+                                          onUpdateTempHp(participant.id, amount, participant.type)
+                                          setTempHpAmount("")
+                                        }
+                                      }}
+                                      disabled={!tempHpAmount || parseInt(tempHpAmount, 10) < 0}
+                                      className="shrink-0 min-h-[44px] bg-blue-500 hover:bg-blue-600 text-white active:scale-95 disabled:opacity-50"
+                                    >
+                                      Appliquer
+                                    </Button>
+                                    {participant.tempHp && participant.tempHp > 0 && (
+                                      <Button
+                                        onClick={() => {
+                                          onUpdateTempHp(participant.id, 0, participant.type)
+                                        }}
+                                        variant="outline"
+                                        className="shrink-0 min-h-[44px] border-blue-500/30 text-blue-400 hover:bg-blue-500/10 active:scale-95"
+                                      >
+                                        Retirer
+                                      </Button>
+                                    )}
+                                  </div>
+                                  <p className="text-xs text-muted-foreground mt-2">
+                                    Les PV temporaires absorbent les dégâts en premier et ne se cumulent pas.
+                                  </p>
+                                </div>
+                              )}
                             </div>
                           </DialogContent>
                         </Dialog>

--- a/components/my-characters-panel.tsx
+++ b/components/my-characters-panel.tsx
@@ -129,8 +129,14 @@ export function MyCharactersPanel({ characters, onUpdateHp, onUpdateInventory, c
                       )}>
                         {character.currentHp}
                       </span>
-                      <span className="text-lg text-muted-foreground">/ {character.maxHp}</span>
+                      <div className="flex items-baseline gap-1">
+                        <span className="text-lg text-muted-foreground">/ {character.maxHp}</span>
+                        {character.tempHp && character.tempHp > 0 && (
+                          <span className="text-lg font-semibold text-blue-400">(+{character.tempHp})</span>
+                        )}
+                      </div>
                     </div>
+                    {/* Regular HP Bar */}
                     <div className="h-3 bg-muted rounded-full overflow-hidden">
                       <div
                         className={cn(
@@ -140,6 +146,15 @@ export function MyCharactersPanel({ characters, onUpdateHp, onUpdateInventory, c
                         style={{ width: `${Math.max(0, (character.currentHp / character.maxHp) * 100)}%` }}
                       />
                     </div>
+                    {/* Temp HP Bar (blue) */}
+                    {character.tempHp && character.tempHp > 0 && (
+                      <div className="h-2 bg-muted rounded-full overflow-hidden mt-1">
+                        <div
+                          className="h-full bg-blue-500 transition-all duration-500 ease-out"
+                          style={{ width: `${Math.min(100, (character.tempHp / character.maxHp) * 100)}%` }}
+                        />
+                      </div>
+                    )}
                   </div>
 
                   {/* HP Controls */}

--- a/components/player-panel.tsx
+++ b/components/player-panel.tsx
@@ -466,8 +466,21 @@ export function PlayerPanel({ players, onUpdateHp, onUpdateInitiative, onUpdateC
                             )}
                           >
                             {player.currentHp} / {player.maxHp}
+                            {player.tempHp && player.tempHp > 0 && (
+                              <span className="text-blue-400 ml-1">(+{player.tempHp})</span>
+                            )}
                           </span>
                         </div>
+                        {/* Temp HP Bar (blue) - shown above regular HP bar */}
+                        {player.tempHp && player.tempHp > 0 && (
+                          <div className="h-1.5 bg-muted rounded-full overflow-hidden">
+                            <div
+                              className="h-full bg-blue-500 transition-all duration-500 ease-out"
+                              style={{ width: `${Math.min(100, (player.tempHp / player.maxHp) * 100)}%` }}
+                            />
+                          </div>
+                        )}
+                        {/* Regular HP Bar */}
                         <div className="h-2.5 bg-muted rounded-full overflow-hidden">
                           <div
                             className={cn(

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1178,9 +1178,10 @@ export async function getCharacterHp(
   return result.rows[0].current_hp;
 }
 
-// Get full persisted status for a character (HP, exhaustion, conditions, conditionDurations, buffs)
+// Get full persisted status for a character (HP, tempHp, exhaustion, conditions, conditionDurations, buffs)
 export interface CharacterStatus {
   currentHp: number | null;
+  tempHp: number | null;
   exhaustionLevel: number | null;
   conditions: string[] | null;
   conditionDurations: Record<string, number> | null;
@@ -1192,17 +1193,18 @@ export async function getCharacterStatus(
   campaignId: number = 1
 ): Promise<CharacterStatus> {
   const result = await pool.query(
-    'SELECT current_hp, exhaustion_level, conditions, condition_durations, buffs FROM character_hp WHERE character_id = $1 AND campaign_id = $2',
+    'SELECT current_hp, temp_hp, exhaustion_level, conditions, condition_durations, buffs FROM character_hp WHERE character_id = $1 AND campaign_id = $2',
     [characterId, campaignId]
   );
 
   if (result.rows.length === 0) {
-    return { currentHp: null, exhaustionLevel: null, conditions: null, conditionDurations: null, buffs: null };
+    return { currentHp: null, tempHp: null, exhaustionLevel: null, conditions: null, conditionDurations: null, buffs: null };
   }
 
   const row = result.rows[0];
   return {
     currentHp: row.current_hp,
+    tempHp: row.temp_hp ?? null,
     exhaustionLevel: row.exhaustion_level ?? null,
     conditions: row.conditions ?? null,
     conditionDurations: row.condition_durations ?? null,

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -49,6 +49,7 @@ export interface ConnectedPlayer {
     level: number;
     currentHp: number;
     maxHp: number;
+    tempHp?: number; // Temporary hit points (D&D 5e)
     ac: number;
     initiative: number;
     conditions: string[];
@@ -153,7 +154,7 @@ export async function clearConnectedPlayers(campaignId: number): Promise<void> {
 }
 
 // Update a specific character's HP across all connected players
-export async function updateCharacterHp(campaignId: number, characterId: string, newHp: number): Promise<void> {
+export async function updateCharacterHp(campaignId: number, characterId: string, newHp: number, tempHp?: number): Promise<void> {
   const client = await getRedis();
   const players = await getConnectedPlayers(campaignId);
 
@@ -162,6 +163,10 @@ export async function updateCharacterHp(campaignId: number, characterId: string,
     for (const char of player.characters) {
       if (String(char.odNumber) === characterId) {
         char.currentHp = newHp;
+        // Update tempHp if provided (undefined means don't change, 0 means remove)
+        if (tempHp !== undefined) {
+          char.tempHp = tempHp > 0 ? tempHp : undefined;
+        }
         updated = true;
         break;
       }

--- a/lib/socket-context/SocketProvider.tsx
+++ b/lib/socket-context/SocketProvider.tsx
@@ -164,6 +164,7 @@ export function SocketProvider({ children }: SocketProviderProps) {
         participantId: data.participantId,
         participantType: data.participantType,
         newHp: data.newHp,
+        tempHp: data.tempHp,
       });
     });
 

--- a/lib/socket-context/reducer.ts
+++ b/lib/socket-context/reducer.ts
@@ -311,7 +311,7 @@ export function socketReducer(state: SocketState, action: SocketAction): SocketS
       };
 
     case 'HP_CHANGE': {
-      const { participantId, participantType, newHp } = action;
+      const { participantId, participantType, newHp, tempHp } = action;
 
       // Update in players/monsters arrays
       let players = state.players;
@@ -319,9 +319,17 @@ export function socketReducer(state: SocketState, action: SocketAction): SocketS
       let connectedPlayers = state.connectedPlayers;
 
       if (participantType === 'player') {
+        // tempHp: 0 means clear temp HP, undefined means don't change
+        const newTempHp = tempHp !== undefined ? (tempHp > 0 ? tempHp : undefined) : undefined;
+        const shouldUpdateTempHp = tempHp !== undefined;
+
         players = state.players.map((p) =>
           p.id === participantId
-            ? { ...p, currentHp: Math.max(0, Math.min(p.maxHp, newHp)) }
+            ? {
+                ...p,
+                currentHp: Math.max(0, Math.min(p.maxHp, newHp)),
+                tempHp: shouldUpdateTempHp ? newTempHp : p.tempHp
+              }
             : p
         );
 
@@ -330,7 +338,11 @@ export function socketReducer(state: SocketState, action: SocketAction): SocketS
           ...cp,
           characters: cp.characters.map((char) =>
             String(char.odNumber) === participantId
-              ? { ...char, currentHp: Math.max(0, Math.min(char.maxHp, newHp)) }
+              ? {
+                  ...char,
+                  currentHp: Math.max(0, Math.min(char.maxHp, newHp)),
+                  tempHp: shouldUpdateTempHp ? newTempHp : char.tempHp
+                }
               : char
           ),
         }));
@@ -347,9 +359,17 @@ export function socketReducer(state: SocketState, action: SocketAction): SocketS
       }
 
       // Update in combat participants
+      // tempHp: 0 means clear temp HP, undefined means don't change
+      const participantNewTempHp = tempHp !== undefined ? (tempHp > 0 ? tempHp : undefined) : undefined;
+      const shouldUpdateParticipantTempHp = tempHp !== undefined;
+
       const participants = state.combatState.participants.map((p) =>
         p.id === participantId && p.type === participantType
-          ? { ...p, currentHp: Math.max(0, Math.min(p.maxHp, newHp)) }
+          ? {
+              ...p,
+              currentHp: Math.max(0, Math.min(p.maxHp, newHp)),
+              tempHp: shouldUpdateParticipantTempHp ? participantNewTempHp : p.tempHp
+            }
           : p
       );
 

--- a/lib/socket-context/types.ts
+++ b/lib/socket-context/types.ts
@@ -114,7 +114,7 @@ export type SocketAction =
 
   // Combat State
   | { type: 'COMBAT_UPDATE'; data: CombatUpdateData }
-  | { type: 'HP_CHANGE'; participantId: string; participantType: 'player' | 'monster'; newHp: number }
+  | { type: 'HP_CHANGE'; participantId: string; participantType: 'player' | 'monster'; newHp: number; tempHp?: number }
   | { type: 'CONDITION_CHANGE'; participantId: string; participantType: 'player' | 'monster'; conditions: string[]; conditionDurations?: Record<string, number> }
   | { type: 'EXHAUSTION_CHANGE'; participantId: string; participantType: 'player' | 'monster'; exhaustionLevel: number }
   | { type: 'BUFF_CHANGE'; participantId: string; participantType: 'player' | 'monster'; buffs: import('../types').ActiveBuff[] }

--- a/lib/socket-events.ts
+++ b/lib/socket-events.ts
@@ -12,6 +12,7 @@ export interface JoinCampaignData {
     level: number;
     currentHp: number;
     maxHp: number;
+    tempHp?: number; // Temporary hit points (D&D 5e)
     ac: number;
     initiative: number;
     conditions: string[];
@@ -33,6 +34,7 @@ export interface ConnectedPlayer {
     level: number;
     currentHp: number;
     maxHp: number;
+    tempHp?: number; // Temporary hit points (D&D 5e)
     ac: number;
     initiative: number;
     conditions: string[];
@@ -74,6 +76,7 @@ export interface HpChangeData {
   participantId: string;
   participantType: 'player' | 'monster';
   newHp: number;
+  tempHp?: number; // Temporary hit points (D&D 5e)
   change: number;
   source: 'dm' | 'player';
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -61,6 +61,7 @@ export interface Character {
   level: number
   currentHp: number
   maxHp: number
+  tempHp?: number // Temporary hit points (D&D 5e)
   ac: number
   conditions: string[]
   conditionDurations?: Record<string, number>
@@ -104,6 +105,7 @@ export interface CombatParticipant {
   initiative: number
   currentHp: number
   maxHp: number
+  tempHp?: number // Temporary hit points (D&D 5e)
   ac?: number // AC for monsters (and optionally players)
   conditions: string[]
   conditionDurations?: Record<string, number> // conditionId -> remaining turns (only during combat)

--- a/migrations/1765186059000_add-temp-hp-column.sql
+++ b/migrations/1765186059000_add-temp-hp-column.sql
@@ -1,0 +1,2 @@
+-- Add temporary HP column for D&D 5e temporary hit points
+ALTER TABLE character_hp ADD COLUMN IF NOT EXISTS temp_hp INTEGER DEFAULT 0;

--- a/server.ts
+++ b/server.ts
@@ -304,16 +304,18 @@ app.prepare().then(() => {
 
             // Use persisted values if available, otherwise use client values
             const currentHp = persistedStatus.currentHp !== null ? persistedStatus.currentHp : char.currentHp;
+            const tempHp = persistedStatus.tempHp !== null ? persistedStatus.tempHp : undefined;
             const conditions = persistedStatus.conditions !== null ? persistedStatus.conditions : (char.conditions || []);
             const conditionDurations = persistedStatus.conditionDurations !== null ? persistedStatus.conditionDurations : {};
             const exhaustionLevel = persistedStatus.exhaustionLevel !== null ? persistedStatus.exhaustionLevel : (char.exhaustionLevel || 0);
             const buffs = persistedStatus.buffs !== null ? persistedStatus.buffs : [];
 
-            console.log(`[Socket.io] Loaded for ${char.name} (${char.odNumber}): HP=${currentHp}, conditions=${JSON.stringify(conditions)}, conditionDurations=${JSON.stringify(conditionDurations)}, exhaustion=${exhaustionLevel}, buffs=${JSON.stringify(buffs)}`);
+            console.log(`[Socket.io] Loaded for ${char.name} (${char.odNumber}): HP=${currentHp}, tempHp=${tempHp}, conditions=${JSON.stringify(conditions)}, conditionDurations=${JSON.stringify(conditionDurations)}, exhaustion=${exhaustionLevel}, buffs=${JSON.stringify(buffs)}`);
             return {
               ...char,
               inventory,
               currentHp,
+              tempHp,
               conditions,
               conditionDurations,
               exhaustionLevel,
@@ -569,21 +571,23 @@ app.prepare().then(() => {
 
         // Persist player HP changes to Redis for session persistence
         if (data.participantType === 'player') {
-          await updateCharacterHp(campaignId, data.participantId, data.newHp);
-          console.log(`[Socket.io] Persisted HP for character ${data.participantId}: ${data.newHp}`);
+          await updateCharacterHp(campaignId, data.participantId, data.newHp, data.tempHp);
+          console.log(`[Socket.io] Persisted HP for character ${data.participantId}: ${data.newHp}, tempHp: ${data.tempHp}`);
         }
 
         // Also update combat state participants HP so it persists across refreshes
         const combatState = await getCombatState(campaignId);
         if (combatState && combatState.participants) {
           const updatedParticipants = combatState.participants.map(p =>
-            p.id === data.participantId ? { ...p, currentHp: data.newHp } : p
+            p.id === data.participantId
+              ? { ...p, currentHp: data.newHp, tempHp: data.tempHp }
+              : p
           );
           await setCombatState(campaignId, {
             ...combatState,
             participants: updatedParticipants,
           });
-          console.log(`[Socket.io] Updated combat state HP for ${data.participantId}: ${data.newHp}`);
+          console.log(`[Socket.io] Updated combat state HP for ${data.participantId}: ${data.newHp}, tempHp: ${data.tempHp}`);
         }
 
         // Broadcast to all clients in room


### PR DESCRIPTION
## Summary

This pull request merges the preprod branch into master with two major features and a critical bug fix:

1. **Temporary Hit Points System (Issue #127)**
   - Added temp HP display (blue bar) in combat panel, groupe panel, and player panel
   - Implemented DM controls to set and remove temporary hit points
   - Enforced D&D 5e damage absorption rules where temp HP absorbs incoming damage first
   - Integrated temp HP persistence in PostgreSQL database and Redis cache
   - Real-time synchronization via socket events for all connected clients

2. **Player Default Tab Fix**
   - Fixed critical bug where players saw a blank screen when logging in
   - Players now correctly start on "Perso" (My Characters) tab instead of non-existent "setup" tab
   - Improves user experience for player onboarding

## Changes Include

- API endpoint for updating temporary HP: `app/api/characters/[characterId]/hp/route.ts`
- UI components updated: combat-panel, my-characters-panel, player-panel
- Database migration: `1765186059000_add-temp-hp-column.sql` (adds temp_hp column)
- Socket event types and reducer logic for real-time sync
- Type definitions for temp HP in character data
- Redis cache updates for temp HP values

## Test Plan

- Verify temp HP is displayed correctly in all panel views
- Test DM controls to set/remove temp HP
- Confirm damage absorption: damage reduces temp HP first, then regular HP
- Verify temp HP persists across sessions
- Test player login: should show character list, not blank screen
- Verify socket events trigger real-time updates for all users in combat

Generated with [Claude Code](https://claude.com/claude-code)