### PR TITLE
feat: Add complete D&D spell system with Notion sync

### DIFF
--- a/app/api/characters/[characterId]/prepared-spells/route.ts
+++ b/app/api/characters/[characterId]/prepared-spells/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from 'next/server';
+import { getPreparedSpells, addPreparedSpell, removePreparedSpell, getSpellById } from '@/lib/db';
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ characterId: string }> }
+) {
+  try {
+    const { characterId } = await params;
+    const { searchParams } = new URL(request.url);
+    const campaignId = parseInt(searchParams.get('campaignId') || '1', 10);
+
+    const preparedSpells = await getPreparedSpells(characterId, campaignId);
+    return NextResponse.json({ success: true, preparedSpells });
+  } catch (error) {
+    console.error('Error fetching prepared spells:', error);
+    return NextResponse.json(
+      { success: false, error: 'Echec du chargement des sorts prepares' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ characterId: string }> }
+) {
+  try {
+    const { characterId } = await params;
+    const { spellId, campaignId = 1, isAlwaysPrepared = false } = await request.json();
+
+    if (!spellId) {
+      return NextResponse.json(
+        { success: false, error: 'spellId est requis' },
+        { status: 400 }
+      );
+    }
+
+    // Verify spell exists
+    const spell = await getSpellById(spellId);
+    if (!spell) {
+      return NextResponse.json(
+        { success: false, error: 'Sort non trouve' },
+        { status: 404 }
+      );
+    }
+
+    const preparedSpell = await addPreparedSpell(
+      characterId,
+      spellId,
+      campaignId,
+      isAlwaysPrepared
+    );
+
+    return NextResponse.json({
+      success: true,
+      preparedSpell: { ...preparedSpell, spell },
+    });
+  } catch (error) {
+    console.error('Error adding prepared spell:', error);
+    return NextResponse.json(
+      { success: false, error: "Echec de l'ajout du sort" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ characterId: string }> }
+) {
+  try {
+    const { characterId } = await params;
+    const { spellId, campaignId = 1 } = await request.json();
+
+    if (!spellId) {
+      return NextResponse.json(
+        { success: false, error: 'spellId est requis' },
+        { status: 400 }
+      );
+    }
+
+    const removed = await removePreparedSpell(characterId, spellId, campaignId);
+
+    return NextResponse.json({ success: true, removed });
+  } catch (error) {
+    console.error('Error removing prepared spell:', error);
+    return NextResponse.json(
+      { success: false, error: 'Echec de la suppression du sort' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/notion/spells/sync/apply/route.ts
+++ b/app/api/notion/spells/sync/apply/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from 'next/server';
+import { upsertSpell, deleteSpellsByNotionId, getSpellCatalog } from '@/lib/db';
+import { fetchSpellsFromNotion } from '@/lib/notion-spells';
+import { buildSpellSyncPreview } from '@/lib/spell-comparison';
+import type { CatalogSpellInput } from '@/lib/types';
+
+interface ApplyRequest {
+  // If provided, use these specific operations
+  toAdd?: CatalogSpellInput[];
+  toUpdate?: { updated: CatalogSpellInput }[];
+  toDeleteNotionIds?: string[];
+  // If true, apply all changes automatically (re-fetch and apply all)
+  applyAll?: boolean;
+}
+
+export async function POST(request: Request) {
+  try {
+    const body: ApplyRequest = await request.json();
+
+    let toAdd: CatalogSpellInput[] = [];
+    let toUpdate: { updated: CatalogSpellInput }[] = [];
+    let toDeleteNotionIds: string[] = [];
+
+    if (body.applyAll) {
+      // Re-fetch from Notion with full content
+      const notionSpells = await fetchSpellsFromNotion(true);
+      const dbSpells = await getSpellCatalog();
+      const preview = buildSpellSyncPreview(notionSpells, dbSpells, false);
+
+      toAdd = preview.toAdd;
+      toUpdate = preview.toUpdate.map(item => ({ updated: item.updated }));
+      toDeleteNotionIds = preview.toDelete.map(spell => spell.notion_id);
+    } else {
+      toAdd = body.toAdd || [];
+      toUpdate = body.toUpdate || [];
+      toDeleteNotionIds = body.toDeleteNotionIds || [];
+    }
+
+    let added = 0;
+    let updated = 0;
+    const errors: string[] = [];
+
+    // Add new spells
+    for (const spell of toAdd) {
+      try {
+        await upsertSpell(spell);
+        added++;
+      } catch (error) {
+        errors.push(`Erreur ajout ${spell.name}: ${error instanceof Error ? error.message : 'Erreur inconnue'}`);
+      }
+    }
+
+    // Update existing spells
+    for (const { updated: spell } of toUpdate) {
+      try {
+        await upsertSpell(spell);
+        updated++;
+      } catch (error) {
+        errors.push(`Erreur mise a jour ${spell.name}: ${error instanceof Error ? error.message : 'Erreur inconnue'}`);
+      }
+    }
+
+    // Delete removed spells
+    const deleteResult = await deleteSpellsByNotionId(toDeleteNotionIds);
+
+    return NextResponse.json({
+      success: true,
+      added,
+      updated,
+      deleted: deleteResult.deleted,
+      errors: [...errors, ...deleteResult.errors],
+    });
+  } catch (error) {
+    console.error('Error applying spell sync:', error);
+    return NextResponse.json(
+      { success: false, error: 'Echec de la synchronisation des sorts' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/notion/spells/sync/preview/route.ts
+++ b/app/api/notion/spells/sync/preview/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { fetchSpellsFromNotion, isSpellsDatabaseConfigured } from '@/lib/notion-spells';
+import { getSpellCatalog } from '@/lib/db';
+import { buildSpellSyncPreview } from '@/lib/spell-comparison';
+
+export async function POST() {
+  try {
+    if (!isSpellsDatabaseConfigured()) {
+      return NextResponse.json(
+        { success: false, error: 'NOTION_SPELLS_DATABASE_ID non configure' },
+        { status: 400 }
+      );
+    }
+
+    // Fetch spells from Notion (without content for faster preview)
+    const notionSpells = await fetchSpellsFromNotion(false);
+
+    // Get current spells from database
+    const dbSpells = await getSpellCatalog();
+
+    // Build sync preview (skip null descriptions in comparison)
+    const preview = buildSpellSyncPreview(notionSpells, dbSpells, true);
+
+    return NextResponse.json({
+      success: true,
+      summary: {
+        toAdd: preview.toAdd.length,
+        toUpdate: preview.toUpdate.length,
+        toDelete: preview.toDelete.length,
+        unchanged: preview.unchanged,
+        total: notionSpells.length,
+      },
+      preview,
+    });
+  } catch (error) {
+    console.error('Error generating spell sync preview:', error);
+    return NextResponse.json(
+      { success: false, error: "Echec de la generation de l'apercu des sorts" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/spells/route.ts
+++ b/app/api/spells/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import { getSpellCatalog } from '@/lib/db';
+
+export async function GET() {
+  try {
+    const spells = await getSpellCatalog();
+    return NextResponse.json({ success: true, spells });
+  } catch (error) {
+    console.error('Error fetching spells:', error);
+    return NextResponse.json(
+      { success: false, error: 'Echec du chargement des sorts' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/spells/search/route.ts
+++ b/app/api/spells/search/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import { searchSpells, getSpellCatalog, getSpellsByLevel } from '@/lib/db';
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const query = searchParams.get('q') || '';
+    const levelParam = searchParams.get('level');
+    const classFilter = searchParams.get('class');
+
+    // Parse level parameter
+    let level: number | undefined;
+    if (levelParam !== null && levelParam !== '' && levelParam !== 'all') {
+      level = parseInt(levelParam, 10);
+      if (isNaN(level)) {
+        level = undefined;
+      }
+    }
+
+    // Parse class filter
+    const classFilterValue = classFilter && classFilter !== 'all' ? classFilter : undefined;
+
+    let spells;
+
+    // If we have any filter, use the search function
+    if (query || level !== undefined || classFilterValue) {
+      spells = await searchSpells(query, level, classFilterValue);
+    } else {
+      // Otherwise return all spells
+      spells = await getSpellCatalog();
+    }
+
+    return NextResponse.json({
+      success: true,
+      count: spells.length,
+      spells,
+    });
+  } catch (error) {
+    console.error('Error searching spells:', error);
+    return NextResponse.json(
+      { success: false, error: 'Echec de la recherche de sorts' },
+      { status: 500 }
+    );
+  }
+}

--- a/components/settings-panel.tsx
+++ b/components/settings-panel.tsx
@@ -16,6 +16,7 @@ import { toast } from "sonner"
 import { Save, Key, Loader2, RefreshCw } from "lucide-react"
 import { NotionSyncButton } from "@/components/notion-sync-button"
 import { ItemSyncDialog } from "@/components/item-sync-dialog"
+import { SpellSyncDialog } from "@/components/spell-sync-dialog"
 
 interface SettingsPanelProps {
   open: boolean
@@ -221,11 +222,12 @@ export function SettingsPanel({
               Synchronisation Notion
             </h4>
             <p className="text-xs text-muted-foreground">
-              Synchronisez vos données depuis Notion (monstres et items).
+              Synchronisez vos données depuis Notion (monstres, items et sorts).
             </p>
             <div className="flex flex-col gap-2">
               <NotionSyncButton onSyncComplete={onMonsterSyncComplete} />
               <ItemSyncDialog />
+              <SpellSyncDialog />
             </div>
           </div>
 

--- a/components/spell-detail.tsx
+++ b/components/spell-detail.tsx
@@ -1,0 +1,224 @@
+"use client"
+
+import { useState } from "react"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Separator } from "@/components/ui/separator"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Zap,
+  Target,
+  Hourglass,
+  Sparkles,
+  Focus,
+  Wand2,
+} from "lucide-react"
+import type { CatalogSpell } from "@/lib/types"
+
+interface SpellDetailProps {
+  spell: CatalogSpell
+  onCast?: (spell: CatalogSpell, slotLevel: number) => void
+  availableSlots?: Record<number, number>  // {1: 4, 2: 3, ...}
+  showCastButton?: boolean
+}
+
+export function SpellDetail({
+  spell,
+  onCast,
+  availableSlots,
+  showCastButton = false,
+}: SpellDetailProps) {
+  const getLevelLabel = (level: number) => {
+    if (level === 0) return "Tour de magie"
+    return `Sort de niveau ${level}`
+  }
+
+  // Parse components to show icons
+  const hasVerbal = spell.components?.toUpperCase().includes("V")
+  const hasSomatic = spell.components?.toUpperCase().includes("S")
+  const hasMaterial = spell.components?.toUpperCase().includes("M")
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div>
+        <h3 className="text-lg font-bold text-purple-400">{spell.name}</h3>
+        <p className="text-sm text-muted-foreground italic">
+          {getLevelLabel(spell.level)}
+        </p>
+      </div>
+
+      {/* Action type - prominent display */}
+      {spell.casting_time && (
+        <div className="flex items-center gap-2 p-2 rounded-md bg-purple-500/10 border border-purple-500/30">
+          <Zap className="w-4 h-4 text-purple-400" />
+          <span className="text-sm font-medium">{spell.casting_time}</span>
+        </div>
+      )}
+
+      {/* Quick info */}
+      <div className="grid grid-cols-2 gap-2 text-sm">
+        {spell.range && (
+          <div className="flex items-center gap-2">
+            <Target className="w-4 h-4 text-muted-foreground" />
+            <span>{spell.range}</span>
+          </div>
+        )}
+        {spell.duration && (
+          <div className="flex items-center gap-2">
+            <Hourglass className="w-4 h-4 text-muted-foreground" />
+            <span>{spell.duration}</span>
+          </div>
+        )}
+        {spell.components && (
+          <div className="flex items-center gap-2">
+            <Sparkles className="w-4 h-4 text-muted-foreground" />
+            <span>{spell.components}</span>
+          </div>
+        )}
+      </div>
+
+      {/* Component badges */}
+      <div className="flex gap-1">
+        {hasVerbal && (
+          <Badge variant="outline" className="text-xs">
+            V
+          </Badge>
+        )}
+        {hasSomatic && (
+          <Badge variant="outline" className="text-xs">
+            S
+          </Badge>
+        )}
+        {hasMaterial && (
+          <Badge variant="outline" className="text-xs">
+            M
+          </Badge>
+        )}
+      </div>
+
+      {/* Concentration badge */}
+      {spell.concentration && (
+        <Badge
+          variant="outline"
+          className="text-amber-400 border-amber-500/50"
+        >
+          <Focus className="w-3 h-3 mr-1" />
+          Concentration
+        </Badge>
+      )}
+
+      <Separator />
+
+      {/* Description */}
+      {spell.description && (
+        <div className="text-sm prose prose-sm prose-invert max-w-none">
+          <p className="whitespace-pre-wrap">{spell.description}</p>
+        </div>
+      )}
+
+      {/* Higher levels */}
+      {spell.higher_levels && (
+        <div className="text-sm">
+          <p className="font-medium text-purple-400 mb-1">
+            Aux niveaux superieurs
+          </p>
+          <p className="text-muted-foreground">{spell.higher_levels}</p>
+        </div>
+      )}
+
+      {/* Classes */}
+      {spell.classes && spell.classes.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {spell.classes.map((cls) => (
+            <Badge key={cls} variant="secondary" className="text-xs">
+              {cls}
+            </Badge>
+          ))}
+        </div>
+      )}
+
+      {/* Cast button (if enabled) */}
+      {showCastButton && onCast && spell.level > 0 && availableSlots && (
+        <CastSpellSection
+          spell={spell}
+          availableSlots={availableSlots}
+          onCast={onCast}
+        />
+      )}
+
+      {/* Cantrip cast button (no slot needed) */}
+      {showCastButton && onCast && spell.level === 0 && (
+        <Button
+          type="button"
+          className="w-full bg-purple-600 hover:bg-purple-700"
+          onClick={() => onCast(spell, 0)}
+        >
+          <Wand2 className="w-4 h-4 mr-2" />
+          Lancer le tour de magie
+        </Button>
+      )}
+    </div>
+  )
+}
+
+// Sub-component for casting spells that require slots
+function CastSpellSection({
+  spell,
+  availableSlots,
+  onCast,
+}: {
+  spell: CatalogSpell
+  availableSlots: Record<number, number>
+  onCast: (spell: CatalogSpell, slotLevel: number) => void
+}) {
+  const [selectedLevel, setSelectedLevel] = useState(spell.level.toString())
+
+  // Available levels for upcasting (spell level and higher, with available slots)
+  const availableLevels = Object.entries(availableSlots)
+    .filter(([level, count]) => parseInt(level) >= spell.level && count > 0)
+    .map(([level]) => parseInt(level))
+    .sort((a, b) => a - b)
+
+  if (availableLevels.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground text-center py-2">
+        Aucun emplacement disponible
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-2 pt-2 border-t border-border">
+      <div className="flex items-center gap-2">
+        <span className="text-sm">Lancer au niveau:</span>
+        <Select value={selectedLevel} onValueChange={setSelectedLevel}>
+          <SelectTrigger className="w-[140px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {availableLevels.map((level) => (
+              <SelectItem key={level} value={level.toString()}>
+                Niveau {level} ({availableSlots[level]} dispo)
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <Button
+        type="button"
+        className="w-full bg-purple-600 hover:bg-purple-700"
+        onClick={() => onCast(spell, parseInt(selectedLevel))}
+      >
+        <Wand2 className="w-4 h-4 mr-2" />
+        Lancer le sort
+      </Button>
+    </div>
+  )
+}

--- a/components/spell-picker-dialog.tsx
+++ b/components/spell-picker-dialog.tsx
@@ -1,0 +1,273 @@
+"use client"
+
+import { useState, useEffect, useCallback, useMemo, useRef } from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Badge } from "@/components/ui/badge"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Search, BookOpen, Loader2, Plus, Sparkles, Zap } from "lucide-react"
+import { SpellDetail } from "./spell-detail"
+import type { CatalogSpell } from "@/lib/types"
+
+interface SpellPickerDialogProps {
+  trigger?: React.ReactNode
+  onSelect: (spell: CatalogSpell) => void
+  filterClass?: string // Filter by character class
+  excludeSpellIds?: number[] // Already prepared spells
+}
+
+const SPELL_LEVELS = [
+  { value: "all", label: "Tous les niveaux" },
+  { value: "0", label: "Tour de magie" },
+  { value: "1", label: "Niveau 1" },
+  { value: "2", label: "Niveau 2" },
+  { value: "3", label: "Niveau 3" },
+  { value: "4", label: "Niveau 4" },
+  { value: "5", label: "Niveau 5" },
+  { value: "6", label: "Niveau 6" },
+  { value: "7", label: "Niveau 7" },
+  { value: "8", label: "Niveau 8" },
+  { value: "9", label: "Niveau 9" },
+]
+
+const DND_CLASSES = [
+  "Barde",
+  "Clerc",
+  "Druide",
+  "Ensorceleur",
+  "Magicien",
+  "Occultiste",
+  "Paladin",
+  "Rodeur",
+]
+
+export function SpellPickerDialog({
+  trigger,
+  onSelect,
+  filterClass,
+  excludeSpellIds = [],
+}: SpellPickerDialogProps) {
+  const [open, setOpen] = useState(false)
+  const [search, setSearch] = useState("")
+  const [level, setLevel] = useState<string>("all")
+  const [classFilter, setClassFilter] = useState<string>(filterClass || "all")
+  const [allSpells, setAllSpells] = useState<CatalogSpell[]>([])
+  const [loading, setLoading] = useState(false)
+  const [selectedSpell, setSelectedSpell] = useState<CatalogSpell | null>(null)
+
+  // Stabilize excludeSpellIds reference
+  const excludeIdsRef = useRef<Set<number>>(new Set(excludeSpellIds))
+  excludeIdsRef.current = new Set(excludeSpellIds)
+
+  // Filter spells client-side to avoid re-fetching
+  const spells = useMemo(() => {
+    return allSpells.filter((s) => !excludeIdsRef.current.has(s.id))
+  }, [allSpells])
+
+  // Fetch spells from API
+  const fetchSpells = useCallback(async (
+    searchQuery: string,
+    levelFilter: string,
+    classFilterVal: string
+  ) => {
+    setLoading(true)
+    try {
+      const params = new URLSearchParams()
+      if (searchQuery) params.set("q", searchQuery)
+      if (levelFilter !== "all") params.set("level", levelFilter)
+      if (classFilterVal !== "all") params.set("class", classFilterVal)
+
+      const response = await fetch(`/api/spells/search?${params}`)
+      const data = await response.json()
+
+      if (data.success) {
+        setAllSpells(data.spells)
+      }
+    } catch (error) {
+      console.error("Error fetching spells:", error)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  // Fetch on dialog open
+  useEffect(() => {
+    if (open) {
+      // Reset state
+      setSearch("")
+      setLevel("all")
+      setClassFilter(filterClass || "all")
+      setSelectedSpell(null)
+      // Fetch with initial values
+      fetchSpells("", "all", filterClass || "all")
+    }
+  }, [open, filterClass, fetchSpells])
+
+  // Debounced fetch when filters change
+  useEffect(() => {
+    if (!open) return
+
+    const timer = setTimeout(() => {
+      fetchSpells(search, level, classFilter)
+    }, 300)
+
+    return () => clearTimeout(timer)
+  }, [open, search, level, classFilter, fetchSpells])
+
+  const handleSelect = (spell: CatalogSpell) => {
+    onSelect(spell)
+    setOpen(false)
+  }
+
+  const getLevelLabel = (level: number) => {
+    if (level === 0) return "Tour de magie"
+    return `Niv. ${level}`
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        {trigger || (
+          <Button type="button" variant="outline" size="sm" className="gap-2">
+            <BookOpen className="w-4 h-4" />
+            Ajouter un sort
+          </Button>
+        )}
+      </DialogTrigger>
+      <DialogContent className="max-w-lg max-h-[85vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-purple-400">
+            <Sparkles className="w-5 h-5" />
+            Catalogue des Sorts
+          </DialogTitle>
+        </DialogHeader>
+
+        {/* Filters */}
+        <div className="flex gap-2 flex-wrap">
+          <div className="relative flex-1 min-w-[150px]">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+            <Input
+              placeholder="Rechercher un sort.."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="pl-9"
+            />
+          </div>
+          <Select value={level} onValueChange={setLevel}>
+            <SelectTrigger className="w-[140px]">
+              <SelectValue placeholder="Niveau" />
+            </SelectTrigger>
+            <SelectContent>
+              {SPELL_LEVELS.map((l) => (
+                <SelectItem key={l.value} value={l.value}>
+                  {l.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {/* Results count */}
+        {!loading && spells.length > 0 && !selectedSpell && (
+          <p className="text-sm text-muted-foreground">
+            {spells.length} sort(s) trouve(s)
+          </p>
+        )}
+
+        {/* Results - responsive layout */}
+        <div className="flex-1 min-h-0 mt-2">
+          {selectedSpell ? (
+            // Show spell detail when selected
+            <div className="flex flex-col h-full">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="self-start mb-2 text-muted-foreground"
+                onClick={() => setSelectedSpell(null)}
+              >
+                ← Retour a la liste
+              </Button>
+              <ScrollArea className="flex-1 h-[300px]">
+                <SpellDetail spell={selectedSpell} />
+              </ScrollArea>
+              <Button
+                type="button"
+                className="w-full mt-4 bg-purple-600 hover:bg-purple-700"
+                onClick={() => handleSelect(selectedSpell)}
+              >
+                <Plus className="w-4 h-4 mr-2" />
+                Preparer ce sort
+              </Button>
+            </div>
+          ) : (
+            // Show spell list
+            <ScrollArea className="h-[350px]">
+              {loading ? (
+                <div className="flex items-center justify-center py-12">
+                  <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+                </div>
+              ) : spells.length === 0 ? (
+                <div className="text-center py-12 text-muted-foreground">
+                  <BookOpen className="w-12 h-12 mx-auto mb-2 opacity-50" />
+                  <p>Aucun sort trouve</p>
+                  <p className="text-xs mt-1">
+                    Synchronisez d'abord les sorts depuis Notion
+                  </p>
+                </div>
+              ) : (
+                <div className="space-y-2 pr-2">
+                  {spells.map((spell) => (
+                    <div
+                      key={spell.id}
+                      onClick={() => setSelectedSpell(spell)}
+                      className="p-3 rounded-lg border border-border hover:border-purple-500/50 cursor-pointer transition-colors"
+                    >
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium">{spell.name}</span>
+                        <Badge variant="outline" className="text-xs">
+                          {getLevelLabel(spell.level)}
+                        </Badge>
+                        {spell.concentration && (
+                          <Badge
+                            variant="secondary"
+                            className="text-xs text-amber-400"
+                          >
+                            C
+                          </Badge>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground mt-1">
+                        {spell.casting_time && (
+                          <span className="flex items-center gap-1">
+                            <Zap className="w-3 h-3" />
+                            {spell.casting_time}
+                          </span>
+                        )}
+                        <span>• {spell.classes?.join(", ")}</span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </ScrollArea>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/spell-sync-dialog.tsx
+++ b/components/spell-sync-dialog.tsx
@@ -1,0 +1,381 @@
+"use client"
+
+import { useState } from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import {
+  Loader2,
+  RefreshCw,
+  Plus,
+  Edit,
+  Trash2,
+  Sparkles,
+  Check,
+  AlertCircle,
+} from "lucide-react"
+import type { SpellSyncPreview, CatalogSpell, CatalogSpellInput } from "@/lib/types"
+import { getSpellChangesSummary, getSpellLevelLabel } from "@/lib/spell-comparison"
+
+interface SpellSyncDialogProps {
+  trigger?: React.ReactNode
+  onSyncComplete?: () => void
+}
+
+type SyncState = "idle" | "loading-preview" | "preview" | "applying" | "complete" | "error"
+
+export function SpellSyncDialog({
+  trigger,
+  onSyncComplete,
+}: SpellSyncDialogProps) {
+  const [open, setOpen] = useState(false)
+  const [state, setState] = useState<SyncState>("idle")
+  const [preview, setPreview] = useState<SpellSyncPreview | null>(null)
+  const [summary, setSummary] = useState<{
+    toAdd: number
+    toUpdate: number
+    toDelete: number
+    unchanged: number
+    total: number
+  } | null>(null)
+  const [result, setResult] = useState<{
+    added: number
+    updated: number
+    deleted: number
+    errors: string[]
+  } | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const loadPreview = async () => {
+    setState("loading-preview")
+    setError(null)
+
+    try {
+      const response = await fetch("/api/notion/spells/sync/preview", {
+        method: "POST",
+      })
+      const data = await response.json()
+
+      if (data.success) {
+        setPreview(data.preview)
+        setSummary(data.summary)
+        setState("preview")
+      } else {
+        setError(data.error || "Erreur lors du chargement")
+        setState("error")
+      }
+    } catch (err) {
+      setError("Erreur de connexion")
+      setState("error")
+    }
+  }
+
+  const applySync = async () => {
+    setState("applying")
+    setError(null)
+
+    try {
+      const response = await fetch("/api/notion/spells/sync/apply", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ applyAll: true }),
+      })
+      const data = await response.json()
+
+      if (data.success) {
+        setResult({
+          added: data.added,
+          updated: data.updated,
+          deleted: data.deleted,
+          errors: data.errors || [],
+        })
+        setState("complete")
+        onSyncComplete?.()
+      } else {
+        setError(data.error || "Erreur lors de la synchronisation")
+        setState("error")
+      }
+    } catch (err) {
+      setError("Erreur de connexion")
+      setState("error")
+    }
+  }
+
+  const handleOpenChange = (newOpen: boolean) => {
+    setOpen(newOpen)
+    if (!newOpen) {
+      // Reset state when closing
+      setState("idle")
+      setPreview(null)
+      setSummary(null)
+      setResult(null)
+      setError(null)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        {trigger || (
+          <Button variant="outline" size="sm" className="gap-2">
+            <RefreshCw className="w-4 h-4" />
+            Sync Sorts
+          </Button>
+        )}
+      </DialogTrigger>
+      <DialogContent className="max-w-2xl max-h-[80vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-purple-400">
+            <Sparkles className="w-5 h-5" />
+            Synchronisation des Sorts
+          </DialogTitle>
+          <DialogDescription>
+            Synchronisez les sorts depuis votre base Notion
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Idle state - show preview button */}
+        {state === "idle" && (
+          <div className="flex flex-col items-center py-8 gap-4">
+            <Sparkles className="w-12 h-12 text-purple-400 opacity-50" />
+            <p className="text-muted-foreground text-center">
+              Cliquez sur le bouton ci-dessous pour voir les modifications
+              disponibles
+            </p>
+            <Button onClick={loadPreview} className="gap-2">
+              <RefreshCw className="w-4 h-4" />
+              Charger l'apercu
+            </Button>
+          </div>
+        )}
+
+        {/* Loading preview */}
+        {state === "loading-preview" && (
+          <div className="flex flex-col items-center py-12 gap-4">
+            <Loader2 className="w-8 h-8 animate-spin text-purple-400" />
+            <p className="text-muted-foreground">
+              Chargement des sorts depuis Notion...
+            </p>
+          </div>
+        )}
+
+        {/* Preview state */}
+        {state === "preview" && preview && summary && (
+          <>
+            {/* Summary badges */}
+            <div className="flex gap-2 flex-wrap">
+              <Badge variant="outline" className="gap-1">
+                <Plus className="w-3 h-3 text-green-500" />
+                {summary.toAdd} a ajouter
+              </Badge>
+              <Badge variant="outline" className="gap-1">
+                <Edit className="w-3 h-3 text-amber-500" />
+                {summary.toUpdate} a mettre a jour
+              </Badge>
+              <Badge variant="outline" className="gap-1">
+                <Trash2 className="w-3 h-3 text-red-500" />
+                {summary.toDelete} a supprimer
+              </Badge>
+              <Badge variant="secondary">{summary.unchanged} inchanges</Badge>
+            </div>
+
+            {/* Tabs for different categories */}
+            <Tabs defaultValue="add" className="flex-1 flex flex-col min-h-0">
+              <TabsList className="grid w-full grid-cols-3">
+                <TabsTrigger value="add" className="gap-1">
+                  <Plus className="w-3 h-3" />
+                  Ajouter ({summary.toAdd})
+                </TabsTrigger>
+                <TabsTrigger value="update" className="gap-1">
+                  <Edit className="w-3 h-3" />
+                  Modifier ({summary.toUpdate})
+                </TabsTrigger>
+                <TabsTrigger value="delete" className="gap-1">
+                  <Trash2 className="w-3 h-3" />
+                  Supprimer ({summary.toDelete})
+                </TabsTrigger>
+              </TabsList>
+
+              <TabsContent value="add" className="flex-1 min-h-0 mt-2">
+                <ScrollArea className="h-[250px]">
+                  {preview.toAdd.length === 0 ? (
+                    <p className="text-center text-muted-foreground py-4">
+                      Aucun sort a ajouter
+                    </p>
+                  ) : (
+                    <div className="space-y-2 pr-2">
+                      {preview.toAdd.map((spell) => (
+                        <SpellPreviewCard
+                          key={spell.notion_id}
+                          spell={spell}
+                          action="add"
+                        />
+                      ))}
+                    </div>
+                  )}
+                </ScrollArea>
+              </TabsContent>
+
+              <TabsContent value="update" className="flex-1 min-h-0 mt-2">
+                <ScrollArea className="h-[250px]">
+                  {preview.toUpdate.length === 0 ? (
+                    <p className="text-center text-muted-foreground py-4">
+                      Aucun sort a mettre a jour
+                    </p>
+                  ) : (
+                    <div className="space-y-2 pr-2">
+                      {preview.toUpdate.map((item) => (
+                        <SpellPreviewCard
+                          key={item.existing.notion_id}
+                          spell={item.updated}
+                          action="update"
+                          changes={item.changes}
+                        />
+                      ))}
+                    </div>
+                  )}
+                </ScrollArea>
+              </TabsContent>
+
+              <TabsContent value="delete" className="flex-1 min-h-0 mt-2">
+                <ScrollArea className="h-[250px]">
+                  {preview.toDelete.length === 0 ? (
+                    <p className="text-center text-muted-foreground py-4">
+                      Aucun sort a supprimer
+                    </p>
+                  ) : (
+                    <div className="space-y-2 pr-2">
+                      {preview.toDelete.map((spell) => (
+                        <SpellPreviewCard
+                          key={spell.notion_id}
+                          spell={spell}
+                          action="delete"
+                        />
+                      ))}
+                    </div>
+                  )}
+                </ScrollArea>
+              </TabsContent>
+            </Tabs>
+
+            <DialogFooter>
+              <Button variant="outline" onClick={() => handleOpenChange(false)}>
+                Annuler
+              </Button>
+              <Button
+                onClick={applySync}
+                className="bg-purple-600 hover:bg-purple-700"
+                disabled={
+                  summary.toAdd + summary.toUpdate + summary.toDelete === 0
+                }
+              >
+                Appliquer toutes les modifications
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+
+        {/* Applying state */}
+        {state === "applying" && (
+          <div className="flex flex-col items-center py-12 gap-4">
+            <Loader2 className="w-8 h-8 animate-spin text-purple-400" />
+            <p className="text-muted-foreground">
+              Application des modifications...
+            </p>
+          </div>
+        )}
+
+        {/* Complete state */}
+        {state === "complete" && result && (
+          <div className="flex flex-col items-center py-8 gap-4">
+            <div className="w-12 h-12 rounded-full bg-green-500/20 flex items-center justify-center">
+              <Check className="w-6 h-6 text-green-500" />
+            </div>
+            <p className="text-lg font-medium">Synchronisation terminee</p>
+            <div className="flex gap-4 text-sm">
+              <span className="text-green-500">{result.added} ajoutes</span>
+              <span className="text-amber-500">{result.updated} mis a jour</span>
+              <span className="text-red-500">{result.deleted} supprimes</span>
+            </div>
+            {result.errors.length > 0 && (
+              <div className="text-sm text-red-400 text-center">
+                {result.errors.length} erreur(s)
+              </div>
+            )}
+            <Button onClick={() => handleOpenChange(false)}>Fermer</Button>
+          </div>
+        )}
+
+        {/* Error state */}
+        {state === "error" && (
+          <div className="flex flex-col items-center py-8 gap-4">
+            <div className="w-12 h-12 rounded-full bg-red-500/20 flex items-center justify-center">
+              <AlertCircle className="w-6 h-6 text-red-500" />
+            </div>
+            <p className="text-lg font-medium text-red-400">Erreur</p>
+            <p className="text-sm text-muted-foreground text-center">{error}</p>
+            <div className="flex gap-2">
+              <Button variant="outline" onClick={() => handleOpenChange(false)}>
+                Fermer
+              </Button>
+              <Button onClick={loadPreview}>Reessayer</Button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// Preview card for a spell in the sync dialog
+function SpellPreviewCard({
+  spell,
+  action,
+  changes,
+}: {
+  spell: CatalogSpellInput | CatalogSpell
+  action: "add" | "update" | "delete"
+  changes?: string[]
+}) {
+  const actionColors = {
+    add: "border-green-500/30 bg-green-500/5",
+    update: "border-amber-500/30 bg-amber-500/5",
+    delete: "border-red-500/30 bg-red-500/5",
+  }
+
+  return (
+    <div className={`p-3 rounded-lg border ${actionColors[action]}`}>
+      <div className="flex items-center gap-2">
+        <span className="font-medium">{spell.name}</span>
+        <Badge variant="outline" className="text-xs">
+          {getSpellLevelLabel(spell.level)}
+        </Badge>
+        {spell.concentration && (
+          <Badge variant="secondary" className="text-xs text-amber-400">
+            C
+          </Badge>
+        )}
+      </div>
+      {spell.classes && spell.classes.length > 0 && (
+        <p className="text-xs text-muted-foreground mt-1">
+          {spell.classes.join(", ")}
+        </p>
+      )}
+      {changes && changes.length > 0 && (
+        <p className="text-xs text-amber-400 mt-1">
+          Modifie: {getSpellChangesSummary(changes)}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/components/spellbook-panel.tsx
+++ b/components/spellbook-panel.tsx
@@ -1,11 +1,38 @@
 "use client"
 
-import { BookOpen, Moon, Sun, Sparkles } from "lucide-react"
+import { useState, useEffect, useCallback } from "react"
+import {
+  BookOpen,
+  Moon,
+  Sun,
+  Sparkles,
+  Plus,
+  Wand2,
+  X,
+  ChevronDown,
+  ChevronRight,
+  Focus,
+} from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
 import { ScrollArea } from "@/components/ui/scroll-area"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible"
 import { cn } from "@/lib/utils"
-import type { Character } from "@/lib/types"
+import { getSocket } from "@/lib/socket"
+import { SpellPickerDialog } from "./spell-picker-dialog"
+import { SpellDetail } from "./spell-detail"
+import type { Character, PreparedSpell, CatalogSpell } from "@/lib/types"
 
 // D&D spell level names in French
 const SPELL_LEVELS = [
@@ -25,7 +52,13 @@ interface SpellbookPanelProps {
   onSpellSlotChange: (characterId: string, level: number, delta: number) => void
   onShortRest: (characterId: string) => void
   onLongRest: (characterId: string) => void
+  onCastSpell?: (
+    characterId: string,
+    spell: CatalogSpell,
+    slotLevel: number
+  ) => void
   isDm?: boolean
+  campaignId?: number
 }
 
 export function SpellbookPanel({
@@ -33,13 +66,210 @@ export function SpellbookPanel({
   onSpellSlotChange,
   onShortRest,
   onLongRest,
+  onCastSpell,
   isDm = false,
+  campaignId = 1,
 }: SpellbookPanelProps) {
+  // Prepared spells state per character
+  const [preparedSpellsMap, setPreparedSpellsMap] = useState<
+    Record<string, PreparedSpell[]>
+  >({})
+  const [loadingMap, setLoadingMap] = useState<Record<string, boolean>>({})
+  const [expandedCharacters, setExpandedCharacters] = useState<Set<string>>(
+    new Set()
+  )
+  const [selectedSpellForDetail, setSelectedSpellForDetail] =
+    useState<CatalogSpell | null>(null)
+  const [detailCharacterId, setDetailCharacterId] = useState<string | null>(null)
+
   // Filter to only show characters with spell slots
   const spellcasters = characters.filter((char) => {
     const maxSlots = char.maxSpellSlots || {}
     return Object.keys(maxSlots).length > 0
   })
+
+  // Load prepared spells for all spellcasters
+  const loadPreparedSpells = useCallback(
+    async (characterId: string) => {
+      setLoadingMap((prev) => ({ ...prev, [characterId]: true }))
+      try {
+        const response = await fetch(
+          `/api/characters/${characterId}/prepared-spells?campaignId=${campaignId}`
+        )
+        const data = await response.json()
+        if (data.success) {
+          setPreparedSpellsMap((prev) => ({
+            ...prev,
+            [characterId]: data.preparedSpells,
+          }))
+        }
+      } catch (error) {
+        console.error("Error loading prepared spells:", error)
+      } finally {
+        setLoadingMap((prev) => ({ ...prev, [characterId]: false }))
+      }
+    },
+    [campaignId]
+  )
+
+  // Load all prepared spells on mount
+  useEffect(() => {
+    spellcasters.forEach((char) => {
+      if (!preparedSpellsMap[char.id]) {
+        loadPreparedSpells(char.id)
+      }
+    })
+  }, [spellcasters.map((c) => c.id).join(","), loadPreparedSpells])
+
+  // Listen for prepared spells changes from other clients
+  useEffect(() => {
+    const socket = getSocket()
+
+    const handlePreparedSpellsChange = (data: {
+      participantId: string
+      participantType: "player"
+      preparedSpells: PreparedSpell[]
+      source: "dm" | "player"
+    }) => {
+      // Update local state with received prepared spells
+      setPreparedSpellsMap((prev) => ({
+        ...prev,
+        [data.participantId]: data.preparedSpells,
+      }))
+    }
+
+    socket.on("prepared-spells-change", handlePreparedSpellsChange)
+
+    return () => {
+      socket.off("prepared-spells-change", handlePreparedSpellsChange)
+    }
+  }, [])
+
+  // Add prepared spell
+  const handleAddPreparedSpell = async (
+    characterId: string,
+    spell: CatalogSpell
+  ) => {
+    try {
+      const response = await fetch(
+        `/api/characters/${characterId}/prepared-spells`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ spellId: spell.id, campaignId }),
+        }
+      )
+      const data = await response.json()
+      if (data.success) {
+        // Reload prepared spells and emit socket event
+        setLoadingMap((prev) => ({ ...prev, [characterId]: true }))
+        try {
+          const refreshResponse = await fetch(
+            `/api/characters/${characterId}/prepared-spells?campaignId=${campaignId}`
+          )
+          const refreshData = await refreshResponse.json()
+          if (refreshData.success) {
+            const newPreparedSpells = refreshData.preparedSpells
+            setPreparedSpellsMap((prev) => ({
+              ...prev,
+              [characterId]: newPreparedSpells,
+            }))
+            // Emit socket event for sync
+            const socket = getSocket()
+            socket.emit("prepared-spells-change", {
+              participantId: characterId,
+              participantType: "player" as const,
+              preparedSpells: newPreparedSpells,
+              source: isDm ? "dm" : "player",
+            })
+          }
+        } finally {
+          setLoadingMap((prev) => ({ ...prev, [characterId]: false }))
+        }
+      }
+    } catch (error) {
+      console.error("Error adding prepared spell:", error)
+    }
+  }
+
+  // Remove prepared spell
+  const handleRemovePreparedSpell = async (
+    characterId: string,
+    spellId: number
+  ) => {
+    try {
+      const response = await fetch(
+        `/api/characters/${characterId}/prepared-spells`,
+        {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ spellId, campaignId }),
+        }
+      )
+      const data = await response.json()
+      if (data.success) {
+        // Reload prepared spells and emit socket event
+        setLoadingMap((prev) => ({ ...prev, [characterId]: true }))
+        try {
+          const refreshResponse = await fetch(
+            `/api/characters/${characterId}/prepared-spells?campaignId=${campaignId}`
+          )
+          const refreshData = await refreshResponse.json()
+          if (refreshData.success) {
+            const newPreparedSpells = refreshData.preparedSpells
+            setPreparedSpellsMap((prev) => ({
+              ...prev,
+              [characterId]: newPreparedSpells,
+            }))
+            // Emit socket event for sync
+            const socket = getSocket()
+            socket.emit("prepared-spells-change", {
+              participantId: characterId,
+              participantType: "player" as const,
+              preparedSpells: newPreparedSpells,
+              source: isDm ? "dm" : "player",
+            })
+          }
+        } finally {
+          setLoadingMap((prev) => ({ ...prev, [characterId]: false }))
+        }
+      }
+    } catch (error) {
+      console.error("Error removing prepared spell:", error)
+    }
+  }
+
+  // Cast a spell (consume slot)
+  const handleCastSpell = (
+    characterId: string,
+    spell: CatalogSpell,
+    slotLevel: number
+  ) => {
+    // Close detail dialog
+    setSelectedSpellForDetail(null)
+    setDetailCharacterId(null)
+
+    // Consume spell slot (if not a cantrip)
+    if (slotLevel > 0) {
+      onSpellSlotChange(characterId, slotLevel, -1)
+    }
+
+    // Call parent handler if provided
+    onCastSpell?.(characterId, spell, slotLevel)
+  }
+
+  // Toggle character expansion
+  const toggleExpanded = (characterId: string) => {
+    setExpandedCharacters((prev) => {
+      const next = new Set(prev)
+      if (next.has(characterId)) {
+        next.delete(characterId)
+      } else {
+        next.add(characterId)
+      }
+      return next
+    })
+  }
 
   // Render spell slot circles (filled/empty)
   const renderSlots = (
@@ -68,13 +298,102 @@ export function SpellbookPanel({
                 onSpellSlotChange(characterId, level, 1)
               }
             }}
-            title={index < current ? "Utiliser cet emplacement" : "Restaurer cet emplacement"}
+            title={
+              index < current
+                ? "Utiliser cet emplacement"
+                : "Restaurer cet emplacement"
+            }
           />
         ))}
         <span className="text-xs text-muted-foreground ml-2">
           {current}/{max}
         </span>
       </div>
+    )
+  }
+
+  // Render prepared spells section
+  const renderPreparedSpells = (character: Character) => {
+    const preparedSpells = preparedSpellsMap[character.id] || []
+    const isLoading = loadingMap[character.id]
+    const isExpanded = expandedCharacters.has(character.id)
+    const excludeIds = preparedSpells.map((ps) => ps.spell_id)
+
+    // Group by level
+    const spellsByLevel: Record<number, PreparedSpell[]> = {}
+    preparedSpells.forEach((ps) => {
+      const level = ps.spell?.level ?? 0
+      if (!spellsByLevel[level]) spellsByLevel[level] = []
+      spellsByLevel[level].push(ps)
+    })
+
+    return (
+      <Collapsible open={isExpanded} onOpenChange={() => toggleExpanded(character.id)}>
+        <div className="flex items-center justify-between mb-2">
+          <CollapsibleTrigger asChild>
+            <button className="flex items-center gap-1 text-sm font-medium text-purple-400 hover:text-purple-300 transition-colors">
+              {isExpanded ? (
+                <ChevronDown className="w-4 h-4" />
+              ) : (
+                <ChevronRight className="w-4 h-4" />
+              )}
+              Sorts prepares ({preparedSpells.length})
+            </button>
+          </CollapsibleTrigger>
+          <SpellPickerDialog
+            trigger={
+              <Button type="button" variant="ghost" size="sm" className="h-7 px-2 gap-1">
+                <Plus className="w-3 h-3" />
+                Ajouter
+              </Button>
+            }
+            onSelect={(spell) => handleAddPreparedSpell(character.id, spell)}
+            filterClass={character.class}
+            excludeSpellIds={excludeIds}
+          />
+        </div>
+
+        <CollapsibleContent>
+          {isLoading ? (
+            <div className="text-xs text-muted-foreground py-2">
+              Chargement...
+            </div>
+          ) : preparedSpells.length === 0 ? (
+            <div className="text-xs text-muted-foreground py-2">
+              Aucun sort prepare
+            </div>
+          ) : (
+            <div className="space-y-1 mb-3">
+              {Object.keys(spellsByLevel)
+                .map(Number)
+                .sort((a, b) => a - b)
+                .map((level) => (
+                  <div key={level}>
+                    <div className="text-xs text-muted-foreground mb-1">
+                      {level === 0 ? "Tours de magie" : `Niveau ${level}`}
+                    </div>
+                    {spellsByLevel[level].map((ps) => (
+                      <PreparedSpellCard
+                        key={ps.id}
+                        preparedSpell={ps}
+                        character={character}
+                        onViewDetails={() => {
+                          if (ps.spell) {
+                            setSelectedSpellForDetail(ps.spell)
+                            setDetailCharacterId(character.id)
+                          }
+                        }}
+                        onRemove={() =>
+                          handleRemovePreparedSpell(character.id, ps.spell_id)
+                        }
+                      />
+                    ))}
+                  </div>
+                ))}
+            </div>
+          )}
+        </CollapsibleContent>
+      </Collapsible>
     )
   }
 
@@ -95,26 +414,36 @@ export function SpellbookPanel({
 
     return (
       <div className="space-y-3">
-        {SPELL_LEVELS.filter(({ level }) => (maxSlots[level] || 0) > 0).map(
-          ({ level, name }) => (
-            <div key={level} className="flex items-center justify-between">
-              <span className="text-sm font-medium text-muted-foreground w-20">
-                {name}
-              </span>
-              {renderSlots(
-                currentSlots[level] || 0,
-                maxSlots[level] || 0,
-                character.id,
-                level
-              )}
-            </div>
-          )
-        )}
+        {/* Prepared Spells Section */}
+        {renderPreparedSpells(character)}
+
+        {/* Spell Slots Section */}
+        <div className="pt-2 border-t border-border/30">
+          <div className="text-sm font-medium text-muted-foreground mb-2">
+            Emplacements
+          </div>
+          {SPELL_LEVELS.filter(({ level }) => (maxSlots[level] || 0) > 0).map(
+            ({ level, name }) => (
+              <div key={level} className="flex items-center justify-between mb-2">
+                <span className="text-sm font-medium text-muted-foreground w-20">
+                  {name}
+                </span>
+                {renderSlots(
+                  currentSlots[level] || 0,
+                  maxSlots[level] || 0,
+                  character.id,
+                  level
+                )}
+              </div>
+            )
+          )}
+        </div>
 
         {/* Rest buttons */}
         <div className="flex gap-2 pt-3 border-t border-border/30">
           {character.isWarlock && (
             <Button
+              type="button"
               variant="outline"
               size="sm"
               className="flex-1 text-amber-400 border-amber-500/30 hover:bg-amber-500/10 hover:border-amber-500/50"
@@ -125,6 +454,7 @@ export function SpellbookPanel({
             </Button>
           )}
           <Button
+            type="button"
             variant="outline"
             size="sm"
             className={cn(
@@ -141,46 +471,130 @@ export function SpellbookPanel({
     )
   }
 
+  // Get character for detail dialog
+  const detailCharacter = detailCharacterId
+    ? characters.find((c) => c.id === detailCharacterId)
+    : null
+
   return (
-    <Card className="bg-card border-border h-full flex flex-col">
-      <CardHeader className="pb-3 shrink-0">
-        <CardTitle className="flex items-center gap-2 text-purple-400">
-          <BookOpen className="w-5 h-5" />
-          Grimoire
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="flex-1 overflow-hidden p-0">
-        <ScrollArea className="h-full px-4 md:px-6 pb-6">
-          {spellcasters.length === 0 ? (
-            <div className="text-center text-muted-foreground py-8">
-              <Sparkles className="w-12 h-12 mx-auto mb-3 opacity-30" />
-              <p className="text-sm">Aucun lanceur de sorts</p>
-              <p className="text-xs mt-1 opacity-70">
-                Les personnages avec des emplacements de sort apparaitront ici
-              </p>
-            </div>
-          ) : (
-            <div className="space-y-4">
-              {spellcasters.map((character) => (
-                <div
-                  key={character.id}
-                  className="bg-secondary/30 rounded-lg border border-border/50 p-4"
-                >
-                  <div className="flex items-center justify-between mb-3">
-                    <h3 className="font-bold text-foreground">
-                      {character.name}
-                    </h3>
-                    <span className="text-xs text-muted-foreground">
-                      {character.class} Niv. {character.level}
-                    </span>
+    <>
+      <Card className="bg-card border-border h-full flex flex-col">
+        <CardHeader className="pb-3 shrink-0">
+          <CardTitle className="flex items-center gap-2 text-purple-400">
+            <BookOpen className="w-5 h-5" />
+            Grimoire
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="flex-1 overflow-hidden p-0">
+          <ScrollArea className="h-full px-4 md:px-6 pb-6">
+            {spellcasters.length === 0 ? (
+              <div className="text-center text-muted-foreground py-8">
+                <Sparkles className="w-12 h-12 mx-auto mb-3 opacity-30" />
+                <p className="text-sm">Aucun lanceur de sorts</p>
+                <p className="text-xs mt-1 opacity-70">
+                  Les personnages avec des emplacements de sort apparaitront ici
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-4">
+                {spellcasters.map((character) => (
+                  <div
+                    key={character.id}
+                    className="bg-secondary/30 rounded-lg border border-border/50 p-4"
+                  >
+                    <div className="flex items-center justify-between mb-3">
+                      <h3 className="font-bold text-foreground">
+                        {character.name}
+                      </h3>
+                      <span className="text-xs text-muted-foreground">
+                        {character.class} Niv. {character.level}
+                      </span>
+                    </div>
+                    {renderCharacterSpells(character)}
                   </div>
-                  {renderCharacterSpells(character)}
-                </div>
-              ))}
-            </div>
+                ))}
+              </div>
+            )}
+          </ScrollArea>
+        </CardContent>
+      </Card>
+
+      {/* Spell detail dialog for casting */}
+      <Dialog
+        open={!!selectedSpellForDetail}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSelectedSpellForDetail(null)
+            setDetailCharacterId(null)
+          }
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle className="text-purple-400">
+              {selectedSpellForDetail?.name}
+            </DialogTitle>
+          </DialogHeader>
+          {selectedSpellForDetail && detailCharacter && (
+            <SpellDetail
+              spell={selectedSpellForDetail}
+              showCastButton
+              availableSlots={detailCharacter.spellSlots || {}}
+              onCast={(spell, slotLevel) =>
+                handleCastSpell(detailCharacter.id, spell, slotLevel)
+              }
+            />
           )}
-        </ScrollArea>
-      </CardContent>
-    </Card>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
+
+// Prepared spell card component
+function PreparedSpellCard({
+  preparedSpell,
+  character,
+  onViewDetails,
+  onRemove,
+}: {
+  preparedSpell: PreparedSpell
+  character: Character
+  onViewDetails: () => void
+  onRemove: () => void
+}) {
+  const spell = preparedSpell.spell
+  if (!spell) return null
+
+  return (
+    <div
+      className="flex items-center gap-2 p-2 rounded bg-secondary/50 mb-1 cursor-pointer hover:bg-secondary/70 transition-colors"
+      onClick={onViewDetails}
+    >
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-1">
+          <span className="text-sm font-medium truncate">{spell.name}</span>
+          {spell.concentration && (
+            <Focus className="w-3 h-3 text-amber-400 shrink-0" />
+          )}
+          {spell.level > 0 && (
+            <span className="text-xs text-muted-foreground">Niv.{spell.level}</span>
+          )}
+        </div>
+      </div>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="h-6 px-2 text-red-400 hover:text-red-300 hover:bg-red-500/10"
+        onClick={(e) => {
+          e.stopPropagation()
+          onRemove()
+        }}
+        title="Retirer des sorts prepares"
+      >
+        <X className="w-3 h-3" />
+      </Button>
+    </div>
   )
 }

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -2,7 +2,10 @@ import { Pool } from 'pg';
 import type {
   CatalogItem,
   CatalogItemInput,
+  CatalogSpell,
+  CatalogSpellInput,
   ItemCategory,
+  PreparedSpell,
 } from './types';
 
 const pool = new Pool({
@@ -1212,5 +1215,262 @@ export async function getCharacterStatus(
     buffs: row.buffs ?? null,
     spellSlots: row.spell_slots ?? null,
   };
+}
+
+// ============================================
+// Spell Catalog Functions (for Notion sync)
+// ============================================
+
+export async function getSpellCatalog(): Promise<CatalogSpell[]> {
+  const result = await pool.query(
+    'SELECT * FROM spell_catalog ORDER BY level, name'
+  );
+  return result.rows;
+}
+
+export async function getSpellById(id: number): Promise<CatalogSpell | null> {
+  const result = await pool.query(
+    'SELECT * FROM spell_catalog WHERE id = $1',
+    [id]
+  );
+  return result.rows[0] || null;
+}
+
+export async function getSpellByNotionId(notionId: string): Promise<CatalogSpell | null> {
+  const result = await pool.query(
+    'SELECT * FROM spell_catalog WHERE notion_id = $1',
+    [notionId]
+  );
+  return result.rows[0] || null;
+}
+
+// Map common class names to French spell database names
+const CLASS_NAME_MAP: Record<string, string> = {
+  'Mage': 'Magicien',
+  'Wizard': 'Magicien',
+  'Sorcerer': 'Ensorceleur',
+  'Warlock': 'Occultiste',
+  'Cleric': 'Clerc',
+  'Druid': 'Druide',
+  'Bard': 'Barde',
+  'Ranger': 'Rôdeur',
+  'Rodeur': 'Rôdeur',
+};
+
+export async function searchSpells(
+  query: string,
+  level?: number,
+  classFilter?: string
+): Promise<CatalogSpell[]> {
+  let sql = 'SELECT * FROM spell_catalog WHERE 1=1';
+  const params: any[] = [];
+  let paramIndex = 1;
+
+  if (query) {
+    sql += ` AND (name ILIKE $${paramIndex} OR description ILIKE $${paramIndex})`;
+    params.push(`%${query}%`);
+    paramIndex++;
+  }
+
+  if (level !== undefined && level >= 0) {
+    sql += ` AND level = $${paramIndex}`;
+    params.push(level);
+    paramIndex++;
+  }
+
+  if (classFilter) {
+    // Map class name to French equivalent if needed
+    const mappedClass = CLASS_NAME_MAP[classFilter] || classFilter;
+    sql += ` AND $${paramIndex} = ANY(classes)`;
+    params.push(mappedClass);
+    paramIndex++;
+  }
+
+  sql += ' ORDER BY level, name LIMIT 100';
+
+  const result = await pool.query(sql, params);
+  return result.rows;
+}
+
+export async function getSpellsByLevel(level: number): Promise<CatalogSpell[]> {
+  const result = await pool.query(
+    'SELECT * FROM spell_catalog WHERE level = $1 ORDER BY name',
+    [level]
+  );
+  return result.rows;
+}
+
+export async function upsertSpell(spell: CatalogSpellInput): Promise<CatalogSpell> {
+  const result = await pool.query(
+    `INSERT INTO spell_catalog (
+      notion_id, name, level, classes, casting_time, range, duration,
+      components, concentration, description, higher_levels
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+    ON CONFLICT (notion_id)
+    DO UPDATE SET
+      name = EXCLUDED.name,
+      level = EXCLUDED.level,
+      classes = EXCLUDED.classes,
+      casting_time = EXCLUDED.casting_time,
+      range = EXCLUDED.range,
+      duration = EXCLUDED.duration,
+      components = EXCLUDED.components,
+      concentration = EXCLUDED.concentration,
+      description = EXCLUDED.description,
+      higher_levels = EXCLUDED.higher_levels,
+      updated_at = CURRENT_TIMESTAMP
+    RETURNING *`,
+    [
+      spell.notion_id,
+      spell.name,
+      spell.level,
+      spell.classes,
+      spell.casting_time,
+      spell.range,
+      spell.duration,
+      spell.components,
+      spell.concentration,
+      spell.description,
+      spell.higher_levels,
+    ]
+  );
+  return result.rows[0];
+}
+
+export async function deleteSpellsById(ids: number[]): Promise<{ deleted: number; errors: string[] }> {
+  const errors: string[] = [];
+  let deleted = 0;
+
+  for (const id of ids) {
+    try {
+      const result = await pool.query('DELETE FROM spell_catalog WHERE id = $1', [id]);
+      if (result.rowCount && result.rowCount > 0) deleted++;
+    } catch (error) {
+      errors.push(`Erreur suppression sort ID ${id}: ${error instanceof Error ? error.message : 'Erreur inconnue'}`);
+    }
+  }
+
+  return { deleted, errors };
+}
+
+export async function deleteSpellsByNotionId(notionIds: string[]): Promise<{ deleted: number; errors: string[] }> {
+  const errors: string[] = [];
+  let deleted = 0;
+
+  for (const notionId of notionIds) {
+    try {
+      const result = await pool.query('DELETE FROM spell_catalog WHERE notion_id = $1', [notionId]);
+      if (result.rowCount && result.rowCount > 0) deleted++;
+    } catch (error) {
+      errors.push(`Erreur suppression sort Notion ${notionId}: ${error instanceof Error ? error.message : 'Erreur inconnue'}`);
+    }
+  }
+
+  return { deleted, errors };
+}
+
+// ============================================
+// Prepared Spells Functions
+// ============================================
+
+export async function getPreparedSpells(
+  characterId: string,
+  campaignId: number = 1
+): Promise<PreparedSpell[]> {
+  const result = await pool.query(
+    `SELECT
+      ps.id,
+      ps.character_id,
+      ps.campaign_id,
+      ps.spell_id,
+      ps.is_always_prepared,
+      ps.created_at,
+      sc.id as "spell.id",
+      sc.notion_id as "spell.notion_id",
+      sc.name as "spell.name",
+      sc.level as "spell.level",
+      sc.classes as "spell.classes",
+      sc.casting_time as "spell.casting_time",
+      sc.range as "spell.range",
+      sc.duration as "spell.duration",
+      sc.components as "spell.components",
+      sc.concentration as "spell.concentration",
+      sc.description as "spell.description",
+      sc.higher_levels as "spell.higher_levels",
+      sc.created_at as "spell.created_at",
+      sc.updated_at as "spell.updated_at"
+     FROM character_prepared_spells ps
+     JOIN spell_catalog sc ON ps.spell_id = sc.id
+     WHERE ps.character_id = $1 AND ps.campaign_id = $2
+     ORDER BY sc.level, sc.name`,
+    [characterId, campaignId]
+  );
+
+  // Transform flat result to nested structure
+  return result.rows.map(row => ({
+    id: row.id,
+    character_id: row.character_id,
+    campaign_id: row.campaign_id,
+    spell_id: row.spell_id,
+    is_always_prepared: row.is_always_prepared,
+    spell: {
+      id: row['spell.id'],
+      notion_id: row['spell.notion_id'],
+      name: row['spell.name'],
+      level: row['spell.level'],
+      classes: row['spell.classes'],
+      casting_time: row['spell.casting_time'],
+      range: row['spell.range'],
+      duration: row['spell.duration'],
+      components: row['spell.components'],
+      concentration: row['spell.concentration'],
+      description: row['spell.description'],
+      higher_levels: row['spell.higher_levels'],
+      created_at: row['spell.created_at'],
+      updated_at: row['spell.updated_at'],
+    }
+  }));
+}
+
+export async function addPreparedSpell(
+  characterId: string,
+  spellId: number,
+  campaignId: number = 1,
+  isAlwaysPrepared: boolean = false
+): Promise<PreparedSpell> {
+  const result = await pool.query(
+    `INSERT INTO character_prepared_spells (character_id, campaign_id, spell_id, is_always_prepared)
+     VALUES ($1, $2, $3, $4)
+     ON CONFLICT (character_id, campaign_id, spell_id) DO UPDATE SET
+       is_always_prepared = EXCLUDED.is_always_prepared
+     RETURNING *`,
+    [characterId, campaignId, spellId, isAlwaysPrepared]
+  );
+  return result.rows[0];
+}
+
+export async function removePreparedSpell(
+  characterId: string,
+  spellId: number,
+  campaignId: number = 1
+): Promise<boolean> {
+  const result = await pool.query(
+    `DELETE FROM character_prepared_spells
+     WHERE character_id = $1 AND campaign_id = $2 AND spell_id = $3`,
+    [characterId, campaignId, spellId]
+  );
+  return (result.rowCount ?? 0) > 0;
+}
+
+export async function clearPreparedSpells(
+  characterId: string,
+  campaignId: number = 1
+): Promise<number> {
+  const result = await pool.query(
+    `DELETE FROM character_prepared_spells
+     WHERE character_id = $1 AND campaign_id = $2`,
+    [characterId, campaignId]
+  );
+  return result.rowCount ?? 0;
 }
 

--- a/lib/notion-spells.ts
+++ b/lib/notion-spells.ts
@@ -1,0 +1,352 @@
+import { Client } from '@notionhq/client';
+import type { CatalogSpellInput } from './types';
+
+// Database ID from environment
+const SPELLS_DATABASE_ID = process.env.NOTION_SPELLS_DATABASE_ID;
+
+// Cache for data source IDs (database_id -> data_source_id)
+const dataSourceCache: Map<string, string> = new Map();
+
+/**
+ * Get Notion client instance
+ */
+function getNotionClient() {
+  const token = process.env.NOTION_API_TOKEN;
+
+  if (!token) {
+    throw new Error('NOTION_API_TOKEN is not defined');
+  }
+
+  return new Client({ auth: token });
+}
+
+/**
+ * Get the data_source_id from a database_id (v5 SDK requirement)
+ */
+async function getDataSourceId(notion: Client, databaseId: string): Promise<string> {
+  const cached = dataSourceCache.get(databaseId);
+  if (cached) {
+    return cached;
+  }
+
+  const database = await notion.databases.retrieve({ database_id: databaseId }) as any;
+  const dataSources = database.data_sources;
+  if (!dataSources || dataSources.length === 0) {
+    throw new Error(`No data sources found for database ${databaseId}`);
+  }
+
+  const dataSourceId = dataSources[0].id;
+  dataSourceCache.set(databaseId, dataSourceId);
+
+  return dataSourceId;
+}
+
+/**
+ * Helper function to extract text from Notion rich text property
+ */
+function extractText(richText: any[]): string {
+  if (!richText || !Array.isArray(richText)) return '';
+  return richText.map((rt) => rt.plain_text || '').join('');
+}
+
+/**
+ * Helper function to extract title property
+ */
+function extractTitle(titleProp: any): string {
+  if (!titleProp || !titleProp.title) return '';
+  return extractText(titleProp.title);
+}
+
+/**
+ * Helper function to extract number property
+ */
+function extractNumber(numberProp: any): number | null {
+  if (numberProp === undefined || numberProp === null) return null;
+  if (typeof numberProp === 'number') return numberProp;
+  if (numberProp.number !== undefined) return numberProp.number;
+  return null;
+}
+
+/**
+ * Helper function to extract checkbox property
+ */
+function extractCheckbox(checkboxProp: any): boolean {
+  if (!checkboxProp) return false;
+  if (typeof checkboxProp === 'boolean') return checkboxProp;
+  return checkboxProp.checkbox === true;
+}
+
+/**
+ * Helper function to extract multi_select property (returns all values as array)
+ */
+function extractMultiSelectArray(multiSelectProp: any): string[] {
+  if (!multiSelectProp || !multiSelectProp.multi_select) return [];
+  if (!Array.isArray(multiSelectProp.multi_select)) return [];
+  return multiSelectProp.multi_select.map((item: any) => item.name || '').filter(Boolean);
+}
+
+/**
+ * Helper function to extract select property
+ */
+function extractSelect(selectProp: any): string {
+  if (!selectProp || !selectProp.select) return '';
+  return selectProp.select.name || '';
+}
+
+/**
+ * Fetch all pages from the spells database
+ */
+async function fetchAllPagesFromDatabase(databaseId: string): Promise<any[]> {
+  const notion = getNotionClient();
+  const dataSourceId = await getDataSourceId(notion, databaseId);
+
+  const pages: any[] = [];
+  let hasMore = true;
+  let startCursor: string | undefined;
+
+  while (hasMore) {
+    const response = await notion.dataSources.query({
+      data_source_id: dataSourceId,
+      start_cursor: startCursor,
+    });
+
+    pages.push(...response.results);
+    hasMore = response.has_more;
+    startCursor = response.next_cursor ?? undefined;
+  }
+
+  return pages;
+}
+
+/**
+ * Recursively fetch blocks and their children for page content
+ */
+async function fetchBlocksRecursively(notion: Client, blockId: string, depth: number = 0): Promise<string[]> {
+  if (depth > 3) return []; // Limit recursion depth
+
+  const textParts: string[] = [];
+  let hasMore = true;
+  let startCursor: string | undefined;
+
+  while (hasMore) {
+    const response = await notion.blocks.children.list({
+      block_id: blockId,
+      start_cursor: startCursor,
+    });
+
+    for (const block of response.results as any[]) {
+      const blockType = block.type;
+      const blockContent = block[blockType];
+
+      if (blockContent?.rich_text) {
+        const text = extractText(blockContent.rich_text);
+        if (text) textParts.push(text);
+      }
+
+      if (block.has_children) {
+        const childTexts = await fetchBlocksRecursively(notion, block.id, depth + 1);
+        textParts.push(...childTexts);
+      }
+    }
+
+    hasMore = response.has_more;
+    startCursor = response.next_cursor ?? undefined;
+  }
+
+  return textParts;
+}
+
+/**
+ * Fetch page content (blocks) and extract text
+ */
+async function fetchPageContent(pageId: string): Promise<string> {
+  try {
+    const notion = getNotionClient();
+    const textParts = await fetchBlocksRecursively(notion, pageId);
+    return textParts.join('\n').trim();
+  } catch (error) {
+    console.error(`Error fetching page content for ${pageId}:`, error);
+    return '';
+  }
+}
+
+/**
+ * Fetch page content for a specific notion_id (exported for use in sync apply)
+ */
+export async function fetchSpellPageContentById(notionId: string): Promise<string> {
+  return fetchPageContent(notionId);
+}
+
+/**
+ * Map a Notion page to a spell catalog item
+ */
+async function mapNotionPageToSpell(
+  page: any,
+  fetchContent: boolean = false
+): Promise<CatalogSpellInput | null> {
+  try {
+    const props = page.properties;
+
+    // Extract name (Nom is title property)
+    const name = extractTitle(props.Nom) || '';
+    if (!name) {
+      console.warn('Skipping spell without name:', page.id);
+      return null;
+    }
+
+    // Extract level (Niveau - number property)
+    const level = extractNumber(props.Niveau) ?? 0;
+
+    // Extract classes (Classe - multi_select)
+    const classes = extractMultiSelectArray(props.Classe);
+
+    // Extract casting time (Temps d'incantation - multi_select, rich_text, or select)
+    const casting_time = extractMultiSelectArray(props["Temps d'incantation"]).join(', ') ||
+      extractText(props["Temps d'incantation"]?.rich_text || []) ||
+      extractSelect(props["Temps d'incantation"]) ||
+      null;
+
+    // Extract range (Portée - rich_text or select)
+    const range = extractText(props.Portée?.rich_text || []) ||
+      extractSelect(props.Portée) ||
+      null;
+
+    // Extract duration (Durée - rich_text or select)
+    const duration = extractText(props.Durée?.rich_text || []) ||
+      extractSelect(props.Durée) ||
+      null;
+
+    // Extract components (Composante - multi_select, rich_text, or select)
+    const components = extractMultiSelectArray(props.Composante).map(c => {
+      // Convert full French names to abbreviations
+      if (c === 'Verbale') return 'V';
+      if (c === 'Somatique') return 'S';
+      if (c === 'Matériel') return 'M';
+      return c;
+    }).join(', ') ||
+      extractText(props.Composante?.rich_text || []) ||
+      extractSelect(props.Composante) ||
+      null;
+
+    // Extract concentration (Concentration - checkbox)
+    const concentration = extractCheckbox(props.Concentration);
+
+    // Extract description (Description - rich_text)
+    let description = extractText(props.Description?.rich_text || []) || null;
+
+    // If no description and fetchContent enabled, get page content
+    if (!description && fetchContent) {
+      const pageContent = await fetchPageContent(page.id);
+      if (pageContent) {
+        description = pageContent;
+      }
+    }
+
+    // Extract higher levels text if available (might be in Description or separate)
+    const higher_levels = extractText(props['Niveaux supérieurs']?.rich_text || []) ||
+      extractText(props['À plus haut niveau']?.rich_text || []) ||
+      null;
+
+    return {
+      notion_id: page.id,
+      name,
+      level,
+      classes,
+      casting_time,
+      range,
+      duration,
+      components,
+      concentration,
+      description,
+      higher_levels,
+    };
+  } catch (error) {
+    console.error('Error mapping Notion page to spell:', error);
+    return null;
+  }
+}
+
+/**
+ * Fetch all spells from the Notion database
+ */
+export async function fetchSpellsFromNotion(fetchContent: boolean = false): Promise<CatalogSpellInput[]> {
+  if (!SPELLS_DATABASE_ID) {
+    console.warn('NOTION_SPELLS_DATABASE_ID not configured');
+    return [];
+  }
+
+  const pages = await fetchAllPagesFromDatabase(SPELLS_DATABASE_ID);
+  const spells: CatalogSpellInput[] = [];
+
+  for (const page of pages) {
+    const spell = await mapNotionPageToSpell(page, fetchContent);
+    if (spell) {
+      spells.push(spell);
+    }
+  }
+
+  return spells;
+}
+
+/**
+ * Check if spells database is configured
+ */
+export function isSpellsDatabaseConfigured(): boolean {
+  return !!SPELLS_DATABASE_ID;
+}
+
+/**
+ * Test connection to the spells database
+ */
+export async function testSpellsDatabaseConnection(): Promise<{
+  success: boolean;
+  count?: number;
+  error?: string;
+}> {
+  if (!SPELLS_DATABASE_ID) {
+    return { success: false, error: 'NOTION_SPELLS_DATABASE_ID not configured' };
+  }
+
+  try {
+    const spells = await fetchSpellsFromNotion(false);
+    return { success: true, count: spells.length };
+  } catch (error) {
+    return { success: false, error: String(error) };
+  }
+}
+
+/**
+ * Debug function to get all properties of a spell by notion_id
+ */
+export async function debugGetSpellProperties(notionId: string): Promise<Record<string, string>> {
+  try {
+    const notion = getNotionClient();
+    const page = await notion.pages.retrieve({ page_id: notionId }) as any;
+    const props = page.properties;
+
+    const result: Record<string, string> = {};
+    for (const [key, value] of Object.entries(props)) {
+      const prop = value as any;
+      if (prop.rich_text) {
+        const text = extractText(prop.rich_text);
+        if (text) result[key] = `rich_text: "${text.substring(0, 100)}..."`;
+      } else if (prop.title) {
+        result[key] = `title: "${extractText(prop.title)}"`;
+      } else if (prop.select) {
+        result[key] = `select: "${prop.select?.name || ''}"`;
+      } else if (prop.multi_select) {
+        result[key] = `multi_select: [${prop.multi_select.map((s: any) => s.name).join(', ')}]`;
+      } else if (prop.number !== undefined) {
+        result[key] = `number: ${prop.number}`;
+      } else if (prop.checkbox !== undefined) {
+        result[key] = `checkbox: ${prop.checkbox}`;
+      } else {
+        result[key] = prop.type || 'unknown';
+      }
+    }
+    return result;
+  } catch (error) {
+    console.error(`Error getting properties for ${notionId}:`, error);
+    return {};
+  }
+}

--- a/lib/socket-events.ts
+++ b/lib/socket-events.ts
@@ -1,6 +1,6 @@
 // Socket.io event type definitions
 
-import type { CharacterInventory, ActiveBuff } from './types';
+import type { CharacterInventory, ActiveBuff, PreparedSpell } from './types';
 
 export interface JoinCampaignData {
   campaignId: number;
@@ -214,6 +214,14 @@ export interface SpellSlotChangeData {
   source: 'dm' | 'player';
 }
 
+// Prepared spells change event
+export interface PreparedSpellsChangeData {
+  participantId: string;
+  participantType: 'player';
+  preparedSpells: PreparedSpell[];
+  source: 'dm' | 'player';
+}
+
 // Server to client events
 export interface ServerToClientEvents {
   'combat-update': (data: CombatUpdateData) => void;
@@ -249,6 +257,8 @@ export interface ServerToClientEvents {
   'inventory-update': (data: InventoryUpdateData) => void;
   // Spell slot events
   'spell-slot-change': (data: SpellSlotChangeData) => void;
+  // Prepared spells events
+  'prepared-spells-change': (data: PreparedSpellsChangeData) => void;
 }
 
 // Client to server events
@@ -277,4 +287,6 @@ export interface ClientToServerEvents {
   'inventory-update': (data: InventoryUpdateData) => void;
   // Spell slot events
   'spell-slot-change': (data: SpellSlotChangeData) => void;
+  // Prepared spells events
+  'prepared-spells-change': (data: PreparedSpellsChangeData) => void;
 }

--- a/lib/spell-comparison.ts
+++ b/lib/spell-comparison.ts
@@ -1,0 +1,161 @@
+import type { CatalogSpell, CatalogSpellInput, SpellSyncPreview } from './types';
+
+/**
+ * Compare two spells and return a list of changed fields
+ *
+ * @param existing - Spell from database
+ * @param updated - Spell from Notion
+ * @param skipNullDescription - If true, don't flag description as changed when
+ *                              Notion has null description (used during preview
+ *                              when content isn't fetched yet)
+ */
+export function compareSpells(
+  existing: CatalogSpell,
+  updated: CatalogSpellInput,
+  skipNullDescription: boolean = false
+): string[] {
+  const changes: string[] = [];
+
+  if (existing.name !== updated.name) {
+    changes.push('name');
+  }
+  if (existing.level !== updated.level) {
+    changes.push('level');
+  }
+  if (existing.casting_time !== updated.casting_time) {
+    changes.push('casting_time');
+  }
+  if (existing.range !== updated.range) {
+    changes.push('range');
+  }
+  if (existing.duration !== updated.duration) {
+    changes.push('duration');
+  }
+  if (existing.components !== updated.components) {
+    changes.push('components');
+  }
+  if (existing.concentration !== updated.concentration) {
+    changes.push('concentration');
+  }
+
+  // Description comparison:
+  // - If skipNullDescription is true and updated.description is null, don't flag as changed
+  //   (because we didn't fetch page content during preview)
+  // - Otherwise, compare normally
+  if (skipNullDescription) {
+    if (updated.description !== null && existing.description !== updated.description) {
+      changes.push('description');
+    }
+  } else {
+    if (existing.description !== updated.description) {
+      changes.push('description');
+    }
+  }
+
+  if (existing.higher_levels !== updated.higher_levels) {
+    changes.push('higher_levels');
+  }
+
+  // Compare classes array (sorted for consistent comparison)
+  const existingClasses = JSON.stringify([...(existing.classes || [])].sort());
+  const updatedClasses = JSON.stringify([...(updated.classes || [])].sort());
+  if (existingClasses !== updatedClasses) {
+    changes.push('classes');
+  }
+
+  return changes;
+}
+
+/**
+ * Build a sync preview comparing Notion spells with database spells
+ *
+ * @param notionSpells - Spells fetched from Notion
+ * @param dbSpells - Spells from local database
+ * @param skipNullDescription - If true, don't flag spells as changed when
+ *                              Notion description is null (preview mode)
+ */
+export function buildSpellSyncPreview(
+  notionSpells: CatalogSpellInput[],
+  dbSpells: CatalogSpell[],
+  skipNullDescription: boolean = false
+): SpellSyncPreview {
+  // Create a map of existing spells by notion_id for quick lookup
+  const dbSpellsByNotionId = new Map<string, CatalogSpell>();
+  for (const spell of dbSpells) {
+    dbSpellsByNotionId.set(spell.notion_id, spell);
+  }
+
+  // Track which notion_ids are in the new data
+  const notionIds = new Set<string>();
+
+  const toAdd: CatalogSpellInput[] = [];
+  const toUpdate: { existing: CatalogSpell; updated: CatalogSpellInput; changes: string[] }[] = [];
+  let unchanged = 0;
+
+  // Process each Notion spell
+  for (const notionSpell of notionSpells) {
+    notionIds.add(notionSpell.notion_id);
+
+    const existingSpell = dbSpellsByNotionId.get(notionSpell.notion_id);
+
+    if (!existingSpell) {
+      // New spell to add
+      toAdd.push(notionSpell);
+    } else {
+      // Check if spell has changed (pass skipNullDescription flag)
+      const changes = compareSpells(existingSpell, notionSpell, skipNullDescription);
+      if (changes.length > 0) {
+        toUpdate.push({
+          existing: existingSpell,
+          updated: notionSpell,
+          changes,
+        });
+      } else {
+        unchanged++;
+      }
+    }
+  }
+
+  // Find spells to delete (in DB but not in Notion anymore)
+  const toDelete: CatalogSpell[] = [];
+  for (const dbSpell of dbSpells) {
+    if (!notionIds.has(dbSpell.notion_id)) {
+      toDelete.push(dbSpell);
+    }
+  }
+
+  return {
+    toAdd,
+    toUpdate,
+    toDelete,
+    unchanged,
+  };
+}
+
+/**
+ * Get a human-readable summary of changes (French)
+ */
+export function getSpellChangesSummary(changes: string[]): string {
+  const fieldLabels: Record<string, string> = {
+    name: 'Nom',
+    level: 'Niveau',
+    classes: 'Classes',
+    casting_time: "Temps d'incantation",
+    range: 'Portée',
+    duration: 'Durée',
+    components: 'Composantes',
+    concentration: 'Concentration',
+    description: 'Description',
+    higher_levels: 'Niveaux supérieurs',
+  };
+
+  return changes.map(field => fieldLabels[field] || field).join(', ');
+}
+
+/**
+ * Get spell level label in French
+ */
+export function getSpellLevelLabel(level: number): string {
+  if (level === 0) return 'Tour de magie';
+  return `Niveau ${level}`;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -672,3 +672,52 @@ export interface ItemSyncResult {
   deleted: number;
   errors: string[];
 }
+
+// ============================================
+// Spell Catalog Types (for Notion sync)
+// ============================================
+
+export interface CatalogSpell {
+  id: number;
+  notion_id: string;
+  name: string;
+  level: number;                    // 0 = cantrip, 1-9 = spell levels
+  classes: string[];                // ['Magicien', 'Sorcier', 'Barde']
+  casting_time: string | null;      // Temps d'incantation
+  range: string | null;             // Portée
+  duration: string | null;          // Durée
+  components: string | null;        // V, S, M
+  concentration: boolean;
+  description: string | null;
+  higher_levels: string | null;     // At higher levels
+  created_at: string;
+  updated_at: string;
+}
+
+// For creating/updating spells (without id and timestamps)
+export type CatalogSpellInput = Omit<CatalogSpell, 'id' | 'created_at' | 'updated_at'>;
+
+export interface SpellSyncPreview {
+  toAdd: CatalogSpellInput[];
+  toUpdate: { existing: CatalogSpell; updated: CatalogSpellInput; changes: string[] }[];
+  toDelete: CatalogSpell[];
+  unchanged: number;
+}
+
+export interface SpellSyncResult {
+  success: boolean;
+  added: number;
+  updated: number;
+  deleted: number;
+  errors: string[];
+}
+
+// Prepared spell on a character
+export interface PreparedSpell {
+  id: number;
+  character_id: string;
+  campaign_id: number;
+  spell_id: number;
+  is_always_prepared: boolean;
+  spell?: CatalogSpell;             // Joined spell data
+}

--- a/migrations/1765200000000_add-spell-catalog.sql
+++ b/migrations/1765200000000_add-spell-catalog.sql
@@ -1,0 +1,23 @@
+-- Spell catalog table for storing spells synced from Notion
+CREATE TABLE IF NOT EXISTS spell_catalog (
+    id SERIAL PRIMARY KEY,
+    notion_id TEXT NOT NULL UNIQUE,
+    name VARCHAR(255) NOT NULL,
+    level INTEGER NOT NULL DEFAULT 0,
+    classes TEXT[] NOT NULL DEFAULT '{}',
+    casting_time VARCHAR(100),
+    range VARCHAR(100),
+    duration VARCHAR(100),
+    components VARCHAR(100),
+    concentration BOOLEAN NOT NULL DEFAULT FALSE,
+    description TEXT,
+    higher_levels TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Indexes for efficient querying
+CREATE INDEX IF NOT EXISTS idx_spell_catalog_level ON spell_catalog(level);
+CREATE INDEX IF NOT EXISTS idx_spell_catalog_name ON spell_catalog(name);
+CREATE INDEX IF NOT EXISTS idx_spell_catalog_notion_id ON spell_catalog(notion_id);
+CREATE INDEX IF NOT EXISTS idx_spell_catalog_classes ON spell_catalog USING GIN(classes);

--- a/migrations/1765200001000_add-prepared-spells.sql
+++ b/migrations/1765200001000_add-prepared-spells.sql
@@ -1,0 +1,14 @@
+-- Character prepared spells table
+-- Links characters to spells they have prepared
+CREATE TABLE IF NOT EXISTS character_prepared_spells (
+    id SERIAL PRIMARY KEY,
+    character_id TEXT NOT NULL,
+    campaign_id INTEGER NOT NULL DEFAULT 1,
+    spell_id INTEGER NOT NULL REFERENCES spell_catalog(id) ON DELETE CASCADE,
+    is_always_prepared BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(character_id, campaign_id, spell_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_prepared_spells_character ON character_prepared_spells(character_id, campaign_id);
+CREATE INDEX IF NOT EXISTS idx_prepared_spells_spell ON character_prepared_spells(spell_id);

--- a/server.ts
+++ b/server.ts
@@ -164,6 +164,13 @@ interface SpellSlotChangeData {
   source: 'dm' | 'player';
 }
 
+interface PreparedSpellsChangeData {
+  participantId: string;
+  participantType: 'player';
+  preparedSpells: any[]; // Use any to avoid importing full type definition
+  source: 'dm' | 'player';
+}
+
 interface AmbientEffectData {
   effect: 'none' | 'rain' | 'fog' | 'fire' | 'snow' | 'sandstorm' | 'crit-fail' | 'crit-success' | 'concentration-broken';
 }
@@ -768,6 +775,16 @@ app.prepare().then(() => {
         // Broadcast to all clients in room
         io.to(room).emit('spell-slot-change', data);
         console.log(`[Socket.io] Spell slot change in ${room}:`, data.participantId, 'by', data.source);
+      }
+    });
+
+    // Prepared spells changes
+    socket.on('prepared-spells-change', (data: PreparedSpellsChangeData) => {
+      if (socket.data.campaignId) {
+        const room = `campaign-${socket.data.campaignId}`;
+        // Broadcast to all clients in room
+        io.to(room).emit('prepared-spells-change', data);
+        console.log(`[Socket.io] Prepared spells change in ${room}:`, data.participantId, 'by', data.source);
       }
     });
 


### PR DESCRIPTION
## Summary
- Add spell catalog database with Notion sync (preview/apply workflow)
- Add prepared spells per character with real-time sync via sockets
- Create spell picker dialog with search/filter by name, level, class
- Create spell detail component with cast button and upcasting support
- Fix Notion field mapping for multi_select types (casting_time, components)

## Test plan
- [ ] Sync spells from Notion in Settings
- [ ] Add prepared spells to a spellcaster character
- [ ] View spell details and cast spells (consumes spell slots)
- [ ] Verify real-time sync between DM and player views

🤖 Generated with [Claude Code](https://claude.com/claude-code)