### PR TITLE
feat: Scroll spell selection and resistance potion types (#138)

### DIFF
--- a/app/api/spells/[id]/route.ts
+++ b/app/api/spells/[id]/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+import { getSpellById } from '@/lib/db';
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const spellId = parseInt(id, 10);
+
+    if (isNaN(spellId)) {
+      return NextResponse.json(
+        { success: false, error: 'ID de sort invalide' },
+        { status: 400 }
+      );
+    }
+
+    const spell = await getSpellById(spellId);
+
+    if (!spell) {
+      return NextResponse.json(
+        { success: false, error: 'Sort non trouvé' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ success: true, spell });
+  } catch (error) {
+    console.error('Error fetching spell:', error);
+    return NextResponse.json(
+      { success: false, error: 'Echec du chargement du sort' },
+      { status: 500 }
+    );
+  }
+}

--- a/components/inventory-manager.tsx
+++ b/components/inventory-manager.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useMemo } from "react"
 import {
   Package,
   Plus,
@@ -11,6 +11,8 @@ import {
   Pill,
   Search,
   X,
+  BookOpen,
+  Scroll,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
@@ -26,10 +28,13 @@ import { ScrollArea } from "@/components/ui/scroll-area"
 import { Badge } from "@/components/ui/badge"
 import { cn } from "@/lib/utils"
 import { toast } from "sonner"
-import type { CharacterInventory, EquipmentItem, ConsumableItem, MiscItem, CurrencyInventory, CatalogItem } from "@/lib/types"
+import type { CharacterInventory, EquipmentItem, ConsumableItem, MiscItem, CurrencyInventory, CatalogItem, CatalogSpell, ResistanceType } from "@/lib/types"
 import { DEFAULT_INVENTORY } from "@/lib/types"
 import { ItemAutocomplete } from "@/components/item-autocomplete"
 import { ItemPickerDialog } from "@/components/item-picker-dialog"
+import { ScrollSpellDialog } from "@/components/scroll-spell-dialog"
+import { ResistanceTypeDialog } from "@/components/resistance-type-dialog"
+import { SpellDetail } from "@/components/spell-detail"
 
 // Rarity color mapping (D&D style)
 function getRarityStyle(rarity: string | null | undefined): string {
@@ -69,6 +74,34 @@ function checkRequiresAttunement(properties: Record<string, unknown> | undefined
   return false
 }
 
+// Resistance type color mapping (matching resistance-type-dialog.tsx)
+function getResistanceStyle(type: string): string {
+  switch (type) {
+    case 'Acide':
+      return 'bg-lime-500/20 text-lime-400 border-lime-500/50'
+    case 'Froid':
+      return 'bg-cyan-500/20 text-cyan-400 border-cyan-500/50'
+    case 'Feu':
+      return 'bg-orange-500/20 text-orange-400 border-orange-500/50'
+    case 'Force':
+      return 'bg-indigo-500/20 text-indigo-400 border-indigo-500/50'
+    case 'Foudre':
+      return 'bg-yellow-500/20 text-yellow-400 border-yellow-500/50'
+    case 'Nécrotique':
+      return 'bg-purple-500/20 text-purple-400 border-purple-500/50'
+    case 'Poison':
+      return 'bg-green-500/20 text-green-400 border-green-500/50'
+    case 'Psychique':
+      return 'bg-pink-500/20 text-pink-400 border-pink-500/50'
+    case 'Radiant':
+      return 'bg-amber-500/20 text-amber-400 border-amber-500/50'
+    case 'Tonnerre':
+      return 'bg-blue-500/20 text-blue-400 border-blue-500/50'
+    default:
+      return 'bg-blue-500/20 text-blue-400 border-blue-500/50'
+  }
+}
+
 // Item detail type for the detail dialog
 type DetailItem = {
   name: string;
@@ -77,6 +110,11 @@ type DetailItem = {
   type: 'equipment' | 'consumable' | 'misc';
   quantity?: number;
   equipped?: boolean;
+  linkedSpell?: {
+    id: number;
+    name: string;
+    level: number;
+  };
 };
 
 interface InventoryManagerProps {
@@ -120,10 +158,12 @@ export function InventoryManager({
 
   // Equipment state
   const [newEquipmentName, setNewEquipmentName] = useState("")
+  const [equipmentSearch, setEquipmentSearch] = useState("")
 
   // Consumables state
   const [newConsumableName, setNewConsumableName] = useState("")
   const [newConsumableQty, setNewConsumableQty] = useState("1")
+  const [consumableSearch, setConsumableSearch] = useState("")
 
   // Currency local state
   const [localCurrency, setLocalCurrency] = useState(inventory.currency)
@@ -149,11 +189,39 @@ export function InventoryManager({
 
   // Detail dialog state
   const [detailItem, setDetailItem] = useState<DetailItem | null>(null)
+  const [viewingDetailSpell, setViewingDetailSpell] = useState<CatalogSpell | null>(null)
 
   // Catalog item storage for adding with details
   const [pendingEquipment, setPendingEquipment] = useState<{description?: string, rarity?: string, catalogNotionId?: string}>({})
   const [pendingConsumable, setPendingConsumable] = useState<{description?: string, rarity?: string, catalogNotionId?: string}>({})
   const [pendingItem, setPendingItem] = useState<{description?: string, rarity?: string, catalogNotionId?: string}>({})
+
+  // Pending items for scroll spell selection and resistance type selection
+  const [pendingScrollItem, setPendingScrollItem] = useState<CatalogItem | null>(null)
+  const [pendingResistanceItem, setPendingResistanceItem] = useState<CatalogItem | null>(null)
+
+  // Filtered lists based on search
+  const filteredEquipment = useMemo(() => {
+    if (!equipmentSearch.trim()) return localInventory.equipment
+    const search = equipmentSearch.toLowerCase()
+    return localInventory.equipment.filter(item =>
+      item.name.toLowerCase().includes(search) ||
+      item.description?.toLowerCase().includes(search) ||
+      item.rarity?.toLowerCase().includes(search)
+    )
+  }, [localInventory.equipment, equipmentSearch])
+
+  const filteredConsumables = useMemo(() => {
+    if (!consumableSearch.trim()) return localInventory.consumables
+    const search = consumableSearch.toLowerCase()
+    return localInventory.consumables.filter(item =>
+      item.name.toLowerCase().includes(search) ||
+      item.description?.toLowerCase().includes(search) ||
+      item.rarity?.toLowerCase().includes(search) ||
+      item.linkedSpell?.name.toLowerCase().includes(search) ||
+      item.resistanceType?.toLowerCase().includes(search)
+    )
+  }, [localInventory.consumables, consumableSearch])
 
   // Equipment handlers
   const addEquipment = () => {
@@ -261,6 +329,19 @@ export function InventoryManager({
 
   // Add consumable directly from catalog item selection (default quantity: 1)
   const addConsumableFromCatalog = (item: CatalogItem) => {
+    // Intercept scrolls (parchemins) - require spell selection
+    if (item.subcategory === 'parchemin') {
+      setPendingScrollItem(item)
+      return
+    }
+
+    // Intercept resistance potions - require type selection
+    if (item.name.toLowerCase().includes('résistance') && item.subcategory === 'potion') {
+      setPendingResistanceItem(item)
+      return
+    }
+
+    // Normal flow for other consumables
     const newItem: ConsumableItem = {
       id: `cons-${Date.now()}`,
       name: item.name,
@@ -278,6 +359,54 @@ export function InventoryManager({
     setNewConsumableName("")
     setNewConsumableQty("1")
     setPendingConsumable({})
+  }
+
+  // Handle scroll spell selection confirmation
+  const handleScrollConfirm = (item: CatalogItem, spell: CatalogSpell) => {
+    const newItem: ConsumableItem = {
+      id: `cons-${Date.now()}`,
+      name: item.name,
+      quantity: 1,
+      description: item.description || undefined,
+      rarity: item.rarity || undefined,
+      catalogNotionId: item.notion_id,
+      linkedSpell: {
+        id: spell.id,
+        name: spell.name,
+        level: spell.level,
+      },
+    }
+    const updatedInventory = {
+      ...localInventory,
+      consumables: [...localInventory.consumables, newItem],
+    }
+    setLocalInventory(updatedInventory)
+    onInventoryChange(updatedInventory)
+    setPendingScrollItem(null)
+    setNewConsumableName("")
+    setNewConsumableQty("1")
+  }
+
+  // Handle resistance potion type selection confirmation
+  const handleResistanceConfirm = (item: CatalogItem, resistanceType: ResistanceType) => {
+    const newItem: ConsumableItem = {
+      id: `cons-${Date.now()}`,
+      name: item.name,
+      quantity: 1,
+      description: item.description || undefined,
+      rarity: item.rarity || undefined,
+      catalogNotionId: item.notion_id,
+      resistanceType,
+    }
+    const updatedInventory = {
+      ...localInventory,
+      consumables: [...localInventory.consumables, newItem],
+    }
+    setLocalInventory(updatedInventory)
+    onInventoryChange(updatedInventory)
+    setPendingResistanceItem(null)
+    setNewConsumableName("")
+    setNewConsumableQty("1")
   }
 
   const updateConsumableQty = (id: string, delta: number) => {
@@ -480,16 +609,36 @@ export function InventoryManager({
                     </Button>
                   }
                 />
-                <Button onClick={addEquipment} size="icon" className="shrink-0">
-                  <Plus className="w-4 h-4" />
-                </Button>
               </div>
             )}
 
-            {/* Attunement counter */}
-            <div className="flex items-center justify-end text-sm">
+            {/* Attunement counter and search */}
+            <div className="flex items-center justify-between gap-2">
+              {localInventory.equipment.length > 0 ? (
+                <div className="relative flex-1">
+                  <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+                  <Input
+                    placeholder="Filtrer l'équipement..."
+                    value={equipmentSearch}
+                    onChange={(e) => setEquipmentSearch(e.target.value)}
+                    className="pl-8 h-8 text-sm"
+                  />
+                  {equipmentSearch && (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="absolute right-1 top-1/2 -translate-y-1/2 h-6 w-6"
+                      onClick={() => setEquipmentSearch("")}
+                    >
+                      <X className="w-3 h-3" />
+                    </Button>
+                  )}
+                </div>
+              ) : (
+                <div />
+              )}
               <span className={cn(
-                "text-muted-foreground",
+                "text-sm text-muted-foreground shrink-0",
                 attunedCount >= 3 && "text-amber-500 font-medium"
               )}>
                 Harmonisés: {attunedCount}/3
@@ -502,9 +651,14 @@ export function InventoryManager({
                   <Package className="w-12 h-12 mx-auto mb-2 opacity-30" />
                   <p className="text-sm">Aucun équipement</p>
                 </div>
+              ) : filteredEquipment.length === 0 ? (
+                <div className="text-center text-muted-foreground py-8">
+                  <Search className="w-12 h-12 mx-auto mb-2 opacity-30" />
+                  <p className="text-sm">Aucun résultat pour "{equipmentSearch}"</p>
+                </div>
               ) : (
                 <div className="space-y-2">
-                  {localInventory.equipment.map((item) => (
+                  {filteredEquipment.map((item) => (
                     <div
                       key={item.id}
                       className={cn(
@@ -610,17 +764,29 @@ export function InventoryManager({
                     </Button>
                   }
                 />
+              </div>
+            )}
+
+            {/* Search filter for consumables */}
+            {localInventory.consumables.length > 0 && (
+              <div className="relative">
+                <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
                 <Input
-                  type="number"
-                  min="1"
-                  placeholder="Qté"
-                  value={newConsumableQty}
-                  onChange={(e) => setNewConsumableQty(e.target.value)}
-                  className="w-16"
+                  placeholder="Filtrer les consommables..."
+                  value={consumableSearch}
+                  onChange={(e) => setConsumableSearch(e.target.value)}
+                  className="pl-8 h-8 text-sm"
                 />
-                <Button onClick={addConsumable} size="icon" className="shrink-0">
-                  <Plus className="w-4 h-4" />
-                </Button>
+                {consumableSearch && (
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="absolute right-1 top-1/2 -translate-y-1/2 h-6 w-6"
+                    onClick={() => setConsumableSearch("")}
+                  >
+                    <X className="w-3 h-3" />
+                  </Button>
+                )}
               </div>
             )}
 
@@ -630,23 +796,29 @@ export function InventoryManager({
                   <Pill className="w-12 h-12 mx-auto mb-2 opacity-30" />
                   <p className="text-sm">Aucun consommable</p>
                 </div>
+              ) : filteredConsumables.length === 0 ? (
+                <div className="text-center text-muted-foreground py-8">
+                  <Search className="w-12 h-12 mx-auto mb-2 opacity-30" />
+                  <p className="text-sm">Aucun résultat pour "{consumableSearch}"</p>
+                </div>
               ) : (
                 <div className="space-y-2">
-                  {localInventory.consumables.map((item) => (
+                  {filteredConsumables.map((item) => (
                     <div
                       key={item.id}
                       className={cn(
                         "p-2 rounded-lg border bg-secondary/30 border-border/50",
-                        (item.description || item.rarity) && "cursor-pointer hover:bg-secondary/50"
+                        (item.description || item.rarity || item.linkedSpell) && "cursor-pointer hover:bg-secondary/50"
                       )}
                       onClick={() => {
-                        if (item.description || item.rarity) {
+                        if (item.description || item.rarity || item.linkedSpell) {
                           setDetailItem({
                             name: item.name,
                             description: item.description,
                             rarity: item.rarity,
                             type: 'consumable',
                             quantity: item.quantity,
+                            linkedSpell: item.linkedSpell,
                           })
                         }
                       }}
@@ -658,6 +830,16 @@ export function InventoryManager({
                             {item.rarity && (
                               <Badge variant="outline" className={`text-xs ${getRarityStyle(item.rarity)}`}>
                                 {item.rarity}
+                              </Badge>
+                            )}
+                            {item.linkedSpell && (
+                              <Badge className="text-xs bg-purple-500/20 text-purple-400 border-purple-500/50">
+                                Niv. {item.linkedSpell.level}: {item.linkedSpell.name}
+                              </Badge>
+                            )}
+                            {item.resistanceType && (
+                              <Badge className={`text-xs ${getResistanceStyle(item.resistanceType)}`}>
+                                {item.resistanceType}
                               </Badge>
                             )}
                           </div>
@@ -842,17 +1024,86 @@ export function InventoryManager({
                 <p className="text-sm whitespace-pre-wrap">{detailItem.description}</p>
               </div>
             )}
+
+            {/* Linked Spell for scrolls */}
+            {detailItem?.linkedSpell && !viewingDetailSpell && (
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <Scroll className="w-4 h-4 text-purple-400" />
+                  <span className="text-sm font-medium">Sort inscrit</span>
+                </div>
+                <Button
+                  variant="outline"
+                  className="w-full justify-start gap-2 bg-purple-500/10 border-purple-500/30 hover:bg-purple-500/20"
+                  onClick={async () => {
+                    // Fetch full spell data
+                    try {
+                      const response = await fetch(`/api/spells/${detailItem.linkedSpell!.id}`)
+                      const data = await response.json()
+                      if (data.success && data.spell) {
+                        setViewingDetailSpell(data.spell)
+                      }
+                    } catch (error) {
+                      console.error('Error fetching spell:', error)
+                    }
+                  }}
+                >
+                  <BookOpen className="w-4 h-4 text-purple-400" />
+                  <span className="text-purple-400">
+                    Niv. {detailItem.linkedSpell.level}: {detailItem.linkedSpell.name}
+                  </span>
+                </Button>
+              </div>
+            )}
+
+            {/* Spell Detail View */}
+            {viewingDetailSpell && (
+              <div className="space-y-3">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-muted-foreground"
+                  onClick={() => setViewingDetailSpell(null)}
+                >
+                  ← Retour à l'objet
+                </Button>
+                <div className="max-h-[300px] overflow-y-auto pr-2">
+                  <SpellDetail spell={viewingDetailSpell} />
+                </div>
+              </div>
+            )}
           </div>
 
           <Button
             variant="outline"
             className="w-full mt-2"
-            onClick={() => setDetailItem(null)}
+            onClick={() => {
+              setDetailItem(null)
+              setViewingDetailSpell(null)
+            }}
           >
             Fermer
           </Button>
         </DialogContent>
       </Dialog>
+
+      {/* Scroll Spell Selection Dialog */}
+      <ScrollSpellDialog
+        open={!!pendingScrollItem}
+        onOpenChange={(open) => !open && setPendingScrollItem(null)}
+        catalogItem={pendingScrollItem}
+        onConfirm={handleScrollConfirm}
+        onCancel={() => setPendingScrollItem(null)}
+      />
+
+      {/* Resistance Type Selection Dialog */}
+      <ResistanceTypeDialog
+        open={!!pendingResistanceItem}
+        onOpenChange={(open) => !open && setPendingResistanceItem(null)}
+        catalogItem={pendingResistanceItem}
+        onConfirm={handleResistanceConfirm}
+        onCancel={() => setPendingResistanceItem(null)}
+      />
     </Dialog>
   )
 }

--- a/components/resistance-type-dialog.tsx
+++ b/components/resistance-type-dialog.tsx
@@ -1,0 +1,198 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Check, FlaskConical, Flame, Snowflake, Zap, Wind, Skull, Brain, Sun, Cloud } from "lucide-react"
+import type { CatalogItem, ResistanceType } from "@/lib/types"
+import { RESISTANCE_TYPES } from "@/lib/types"
+import { cn } from "@/lib/utils"
+
+interface ResistanceTypeDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  catalogItem: CatalogItem | null
+  onConfirm: (item: CatalogItem, resistanceType: ResistanceType) => void
+  onCancel: () => void
+}
+
+// Visual configuration for each resistance type
+const RESISTANCE_CONFIG: Record<ResistanceType, {
+  icon: React.ReactNode
+  color: string
+  bgColor: string
+  borderColor: string
+}> = {
+  'Acide': {
+    icon: <FlaskConical className="w-5 h-5" />,
+    color: 'text-lime-400',
+    bgColor: 'bg-lime-500/20',
+    borderColor: 'border-lime-500/50',
+  },
+  'Froid': {
+    icon: <Snowflake className="w-5 h-5" />,
+    color: 'text-cyan-400',
+    bgColor: 'bg-cyan-500/20',
+    borderColor: 'border-cyan-500/50',
+  },
+  'Feu': {
+    icon: <Flame className="w-5 h-5" />,
+    color: 'text-orange-400',
+    bgColor: 'bg-orange-500/20',
+    borderColor: 'border-orange-500/50',
+  },
+  'Force': {
+    icon: <Wind className="w-5 h-5" />,
+    color: 'text-indigo-400',
+    bgColor: 'bg-indigo-500/20',
+    borderColor: 'border-indigo-500/50',
+  },
+  'Foudre': {
+    icon: <Zap className="w-5 h-5" />,
+    color: 'text-yellow-400',
+    bgColor: 'bg-yellow-500/20',
+    borderColor: 'border-yellow-500/50',
+  },
+  'Nécrotique': {
+    icon: <Skull className="w-5 h-5" />,
+    color: 'text-purple-400',
+    bgColor: 'bg-purple-500/20',
+    borderColor: 'border-purple-500/50',
+  },
+  'Poison': {
+    icon: <FlaskConical className="w-5 h-5" />,
+    color: 'text-green-400',
+    bgColor: 'bg-green-500/20',
+    borderColor: 'border-green-500/50',
+  },
+  'Psychique': {
+    icon: <Brain className="w-5 h-5" />,
+    color: 'text-pink-400',
+    bgColor: 'bg-pink-500/20',
+    borderColor: 'border-pink-500/50',
+  },
+  'Radiant': {
+    icon: <Sun className="w-5 h-5" />,
+    color: 'text-amber-400',
+    bgColor: 'bg-amber-500/20',
+    borderColor: 'border-amber-500/50',
+  },
+  'Tonnerre': {
+    icon: <Cloud className="w-5 h-5" />,
+    color: 'text-blue-400',
+    bgColor: 'bg-blue-500/20',
+    borderColor: 'border-blue-500/50',
+  },
+}
+
+export function ResistanceTypeDialog({
+  open,
+  onOpenChange,
+  catalogItem,
+  onConfirm,
+  onCancel,
+}: ResistanceTypeDialogProps) {
+  const [selectedType, setSelectedType] = useState<ResistanceType | null>(null)
+
+  // Reset selection when dialog opens
+  useEffect(() => {
+    if (open) {
+      setSelectedType(null)
+    }
+  }, [open])
+
+  const handleConfirm = () => {
+    if (selectedType && catalogItem) {
+      onConfirm(catalogItem, selectedType)
+    }
+  }
+
+  const handleCancel = () => {
+    onCancel()
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-blue-400">
+            <FlaskConical className="w-5 h-5" />
+            Type de résistance
+          </DialogTitle>
+          <DialogDescription>
+            {catalogItem && (
+              <span className="text-foreground font-medium">{catalogItem.name}</span>
+            )}
+            {" "}- Sélectionnez le type de dégâts
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Resistance type grid */}
+        <div className="grid grid-cols-2 gap-2">
+          {RESISTANCE_TYPES.map((type) => {
+            const config = RESISTANCE_CONFIG[type]
+            const isSelected = selectedType === type
+
+            return (
+              <button
+                key={type}
+                type="button"
+                onClick={() => setSelectedType(type)}
+                className={cn(
+                  "flex items-center gap-3 p-3 rounded-lg border transition-all",
+                  isSelected
+                    ? `${config.bgColor} ${config.borderColor} ring-2 ring-offset-2 ring-offset-background`
+                    : "border-border hover:border-muted-foreground bg-card"
+                )}
+              >
+                <div className={cn(
+                  "w-8 h-8 rounded-full flex items-center justify-center",
+                  config.bgColor
+                )}>
+                  <span className={config.color}>{config.icon}</span>
+                </div>
+                <span className={cn(
+                  "font-medium text-sm",
+                  isSelected ? config.color : "text-foreground"
+                )}>
+                  {type}
+                </span>
+                {isSelected && (
+                  <Check className={cn("w-4 h-4 ml-auto", config.color)} />
+                )}
+              </button>
+            )
+          })}
+        </div>
+
+        {/* Action buttons */}
+        <div className="flex gap-2 pt-4 border-t border-border">
+          <Button
+            type="button"
+            variant="outline"
+            className="flex-1"
+            onClick={handleCancel}
+          >
+            Annuler
+          </Button>
+          <Button
+            type="button"
+            className="flex-1 bg-blue-600 hover:bg-blue-700"
+            disabled={!selectedType}
+            onClick={handleConfirm}
+          >
+            <FlaskConical className="w-4 h-4 mr-2" />
+            Ajouter la potion
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/scroll-spell-dialog.tsx
+++ b/components/scroll-spell-dialog.tsx
@@ -1,0 +1,310 @@
+"use client"
+
+import { useState, useEffect, useCallback } from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Badge } from "@/components/ui/badge"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Search, BookOpen, Loader2, Scroll, Zap, Check } from "lucide-react"
+import { SpellDetail } from "./spell-detail"
+import type { CatalogSpell, CatalogItem } from "@/lib/types"
+
+interface ScrollSpellDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  catalogItem: CatalogItem | null
+  onConfirm: (item: CatalogItem, spell: CatalogSpell) => void
+  onCancel: () => void
+}
+
+const SPELL_LEVELS = [
+  { value: "all", label: "Tous les niveaux" },
+  { value: "0", label: "Tour de magie" },
+  { value: "1", label: "Niveau 1" },
+  { value: "2", label: "Niveau 2" },
+  { value: "3", label: "Niveau 3" },
+  { value: "4", label: "Niveau 4" },
+  { value: "5", label: "Niveau 5" },
+  { value: "6", label: "Niveau 6" },
+  { value: "7", label: "Niveau 7" },
+  { value: "8", label: "Niveau 8" },
+  { value: "9", label: "Niveau 9" },
+]
+
+export function ScrollSpellDialog({
+  open,
+  onOpenChange,
+  catalogItem,
+  onConfirm,
+  onCancel,
+}: ScrollSpellDialogProps) {
+  const [search, setSearch] = useState("")
+  const [level, setLevel] = useState<string>("all")
+  const [allSpells, setAllSpells] = useState<CatalogSpell[]>([])
+  const [loading, setLoading] = useState(false)
+  const [selectedSpell, setSelectedSpell] = useState<CatalogSpell | null>(null)
+  const [viewingSpell, setViewingSpell] = useState<CatalogSpell | null>(null)
+
+  // Fetch spells from API
+  const fetchSpells = useCallback(async (searchQuery: string, levelFilter: string) => {
+    setLoading(true)
+    try {
+      const params = new URLSearchParams()
+      if (searchQuery) params.set("q", searchQuery)
+      if (levelFilter !== "all") params.set("level", levelFilter)
+
+      const response = await fetch(`/api/spells/search?${params}`)
+      const data = await response.json()
+
+      if (data.success) {
+        setAllSpells(data.spells)
+      }
+    } catch (error) {
+      console.error("Error fetching spells:", error)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  // Reset state when dialog opens
+  useEffect(() => {
+    if (open) {
+      setSearch("")
+      setLevel("all")
+      setSelectedSpell(null)
+      setViewingSpell(null)
+      fetchSpells("", "all")
+    }
+  }, [open, fetchSpells])
+
+  // Debounced fetch when filters change
+  useEffect(() => {
+    if (!open) return
+
+    const timer = setTimeout(() => {
+      fetchSpells(search, level)
+    }, 300)
+
+    return () => clearTimeout(timer)
+  }, [open, search, level, fetchSpells])
+
+  const handleConfirm = () => {
+    if (selectedSpell && catalogItem) {
+      onConfirm(catalogItem, selectedSpell)
+    }
+  }
+
+  const handleCancel = () => {
+    onCancel()
+    onOpenChange(false)
+  }
+
+  const getLevelLabel = (level: number) => {
+    if (level === 0) return "Tour de magie"
+    return `Niv. ${level}`
+  }
+
+  const toggleSpellSelection = (spell: CatalogSpell) => {
+    if (selectedSpell?.id === spell.id) {
+      setSelectedSpell(null)
+    } else {
+      setSelectedSpell(spell)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg max-h-[85vh] flex flex-col overflow-hidden">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-amber-400">
+            <Scroll className="w-5 h-5" />
+            Sélectionner le sort du parchemin
+          </DialogTitle>
+          <DialogDescription>
+            {catalogItem && (
+              <span className="text-foreground font-medium">{catalogItem.name}</span>
+            )}
+            {" "}- Choisissez le sort inscrit sur ce parchemin
+          </DialogDescription>
+        </DialogHeader>
+
+        {viewingSpell ? (
+          // Spell detail view
+          <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="self-start mb-2 text-muted-foreground"
+              onClick={() => setViewingSpell(null)}
+            >
+              ← Retour à la liste
+            </Button>
+            <div className="flex-1 overflow-y-auto pr-2">
+              <SpellDetail spell={viewingSpell} />
+            </div>
+            <Button
+              type="button"
+              className="w-full mt-4 bg-amber-600 hover:bg-amber-700 shrink-0"
+              onClick={() => {
+                setSelectedSpell(viewingSpell)
+                setViewingSpell(null)
+              }}
+            >
+              <Check className="w-4 h-4 mr-2" />
+              Sélectionner ce sort
+            </Button>
+          </div>
+        ) : (
+          <>
+            {/* Filters */}
+            <div className="flex gap-2 flex-wrap">
+              <div className="relative flex-1 min-w-[150px]">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+                <Input
+                  placeholder="Rechercher un sort..."
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  className="pl-9"
+                />
+              </div>
+              <Select value={level} onValueChange={setLevel}>
+                <SelectTrigger className="w-[140px]">
+                  <SelectValue placeholder="Niveau" />
+                </SelectTrigger>
+                <SelectContent>
+                  {SPELL_LEVELS.map((l) => (
+                    <SelectItem key={l.value} value={l.value}>
+                      {l.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {/* Selected spell indicator */}
+            {selectedSpell && (
+              <div className="flex items-center gap-2 p-2 rounded-lg bg-amber-500/20 border border-amber-500/50">
+                <Check className="w-4 h-4 text-amber-400" />
+                <span className="text-sm font-medium text-amber-400">
+                  Sort sélectionné: {selectedSpell.name} (Niv. {selectedSpell.level})
+                </span>
+              </div>
+            )}
+
+            {/* Results - scrollable area */}
+            <div className="flex-1 min-h-0 overflow-y-auto" style={{ maxHeight: '300px' }}>
+              {loading ? (
+                <div className="flex items-center justify-center py-12">
+                  <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+                </div>
+              ) : allSpells.length === 0 ? (
+                <div className="text-center py-12 text-muted-foreground">
+                  <BookOpen className="w-12 h-12 mx-auto mb-2 opacity-50" />
+                  <p>Aucun sort trouvé</p>
+                </div>
+              ) : (
+                <div className="space-y-2 pr-2">
+                  {allSpells.map((spell) => (
+                    <div
+                      key={spell.id}
+                      className={`p-3 rounded-lg border cursor-pointer transition-colors ${
+                        selectedSpell?.id === spell.id
+                          ? "border-amber-500 bg-amber-500/10"
+                          : "border-border hover:border-amber-500/50"
+                      }`}
+                    >
+                      <div
+                        className="flex items-center gap-2"
+                        onClick={() => toggleSpellSelection(spell)}
+                      >
+                        <div className={`w-5 h-5 rounded border flex items-center justify-center ${
+                          selectedSpell?.id === spell.id
+                            ? "border-amber-500 bg-amber-500"
+                            : "border-muted-foreground"
+                        }`}>
+                          {selectedSpell?.id === spell.id && (
+                            <Check className="w-3 h-3 text-white" />
+                          )}
+                        </div>
+                        <span className="font-medium flex-1">{spell.name}</span>
+                        <Badge variant="outline" className="text-xs">
+                          {getLevelLabel(spell.level)}
+                        </Badge>
+                        {spell.concentration && (
+                          <Badge variant="secondary" className="text-xs text-amber-400">
+                            C
+                          </Badge>
+                        )}
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="h-6 px-2 text-xs text-muted-foreground"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            setViewingSpell(spell)
+                          }}
+                        >
+                          Détails
+                        </Button>
+                      </div>
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground mt-1 ml-7">
+                        {spell.casting_time && (
+                          <span className="flex items-center gap-1">
+                            <Zap className="w-3 h-3" />
+                            {spell.casting_time}
+                          </span>
+                        )}
+                        {spell.classes && spell.classes.length > 0 && (
+                          <span>• {spell.classes.join(", ")}</span>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </>
+        )}
+
+        {/* Action buttons - always at bottom using DialogFooter */}
+        {!viewingSpell && (
+          <DialogFooter className="flex gap-2 pt-4 border-t border-border sm:flex-row">
+            <Button
+              type="button"
+              variant="outline"
+              className="flex-1"
+              onClick={handleCancel}
+            >
+              Annuler
+            </Button>
+            <Button
+              type="button"
+              className="flex-1 bg-amber-600 hover:bg-amber-700"
+              disabled={!selectedSpell}
+              onClick={handleConfirm}
+            >
+              <Scroll className="w-4 h-4 mr-2" />
+              Ajouter le parchemin
+            </Button>
+          </DialogFooter>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -16,7 +16,31 @@ export interface ConsumableItem {
   description?: string
   rarity?: string
   catalogNotionId?: string  // Reference to item_catalog for auto-updates
+  // For scrolls (parchemins) - linked spell information
+  linkedSpell?: {
+    id: number
+    name: string
+    level: number
+  }
+  // For resistance potions - selected damage type
+  resistanceType?: ResistanceType
 }
+
+// D&D 5e Resistance Types (damage types) - French
+export const RESISTANCE_TYPES = [
+  'Acide',
+  'Froid',
+  'Feu',
+  'Force',
+  'Foudre',
+  'Nécrotique',
+  'Poison',
+  'Psychique',
+  'Radiant',
+  'Tonnerre',
+] as const
+
+export type ResistanceType = typeof RESISTANCE_TYPES[number]
 
 export interface CurrencyInventory {
   platinum: number  // pp (pièces de platine)


### PR DESCRIPTION
## Summary

- **Scrolls (parchemins)** now require mandatory spell selection from the spell catalog when adding to inventory
- **Resistance potions** prompt for damage type selection from 10 standard D&D 5e types (Acide, Froid, Feu, Force, Foudre, Nécrotique, Poison, Psychique, Radiant, Tonnerre)
- Display linked spell/resistance type as colored badges in inventory
- Add search filter for Equipment and Consumables tabs for easier navigation
- Remove manual "+" buttons - all items must be selected from Notion catalog
- Add spell detail view in item detail dialog for scrolls

## Test plan

- [ ] Add a scroll (parchemin) from catalog and verify spell selection dialog appears
- [ ] Verify scroll cannot be added without selecting a spell
- [ ] Add a resistance potion and verify type selection dialog appears
- [ ] Verify resistance badge displays with correct color matching the selection dialog
- [ ] Verify spell badge displays on scrolls with level and name
- [ ] Test search filter on Equipment tab
- [ ] Test search filter on Consumables tab (including search by spell name for scrolls)
- [ ] Click on scroll item and verify "Voir le sort" button shows spell details
- [ ] Verify "+" buttons are removed from Equipment and Consumables tabs

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)