### PR TITLE
feat: Add temporary HP support for monsters

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1447,6 +1447,38 @@ function CombatTrackerContent() {
     }
   }
 
+  const updateMonsterTempHp = async (id: string, newTempHp: number) => {
+    const monster = monsters.find(m => m.id === id)
+    const participant = combatParticipants.find(p => p.id === id && p.type === 'monster')
+    if (!monster && !participant) return
+
+    // Temp HP cannot be negative
+    const finalTempHp = Math.max(0, newTempHp) || undefined
+    const currentHp = monster?.hp ?? participant?.currentHp ?? 0
+
+    // Update local monsters state
+    setMonsters((prev) =>
+      prev.map((m) => (m.id === id ? { ...m, tempHp: finalTempHp } : m))
+    )
+
+    // Update combat participants if in combat
+    if (combatActive) {
+      setCombatParticipants((prev) =>
+        prev.map((p) => (p.id === id ? { ...p, tempHp: finalTempHp } : p))
+      )
+    }
+
+    // Emit to sync with other clients
+    emitHpChange({
+      participantId: id,
+      participantType: 'monster',
+      newHp: currentHp,
+      tempHp: finalTempHp,
+      change: 0,
+      source: 'dm',
+    })
+  }
+
   const updateMonsterHp = async (id: string, change: number, skipConcentrationCheck = false) => {
     // Try to find in monsters array first, then fall back to combat participants
     const monster = monsters.find(m => m.id === id)
@@ -2890,7 +2922,7 @@ function CombatTrackerContent() {
                   } : undefined}
                   onUpdateTempHp={mode === "mj" ? (id, tempHp, type) => {
                     if (type === "player") updatePlayerTempHp(id, tempHp)
-                    // Note: monsters don't have temp HP in this implementation
+                    else updateMonsterTempHp(id, tempHp)
                   } : undefined}
                   onUpdateConditions={mode === "mj" ? (id, conditions, type, conditionDurations) => {
                     if (type === "player") updatePlayerConditions(id, conditions, conditionDurations)
@@ -3031,7 +3063,7 @@ function CombatTrackerContent() {
                     } : undefined}
                     onUpdateTempHp={mode === "mj" ? (id, tempHp, type) => {
                       if (type === "player") updatePlayerTempHp(id, tempHp)
-                      // Note: monsters don't have temp HP in this implementation
+                      else updateMonsterTempHp(id, tempHp)
                     } : undefined}
                     onUpdateConditions={mode === "mj" ? (id, conditions, type, conditionDurations) => {
                       if (type === "player") updatePlayerConditions(id, conditions, conditionDurations)

--- a/components/combat-panel.tsx
+++ b/components/combat-panel.tsx
@@ -657,8 +657,8 @@ export function CombatPanel({
                                       </Button>
                                     </div>
                                   </div>
-                                  {/* Temp HP Section - Players only */}
-                                  {participant.type === "player" && onUpdateTempHp && (
+                                  {/* Temp HP Section */}
+                                  {onUpdateTempHp && (
                                     <div className="border-t border-border pt-4">
                                       <label className="text-sm text-blue-400 mb-2 block font-medium">
                                         <Shield className="w-4 h-4 inline mr-1" />
@@ -1240,8 +1240,8 @@ export function CombatPanel({
                                   </Button>
                                 </div>
                               </div>
-                              {/* Temp HP Section - Players only (Desktop view) */}
-                              {participant.type === "player" && onUpdateTempHp && (
+                              {/* Temp HP Section (Desktop view) */}
+                              {onUpdateTempHp && (
                                 <div className="border-t border-border pt-4">
                                   <label className="text-sm text-blue-400 mb-2 block font-medium">
                                     <Shield className="w-4 h-4 inline mr-1" />

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -158,6 +158,7 @@ export interface Monster {
   conditions: string[]
   exhaustionLevel: number
   buffs?: ActiveBuff[]
+  tempHp?: number // Temporary hit points
 }
 
 export interface CombatParticipant {


### PR DESCRIPTION
## Summary

This PR adds temporary hit points (temp HP) support for monsters/enemies in the combat tracker, bringing feature parity with player character temp HP management.

## Changes

- **lib/types.ts**: Added optional `tempHp` field to Monster interface
- **app/page.tsx**: 
  - Implemented `updateMonsterTempHp()` function for DM controls
  - Updated combat panel handlers to support temp HP for monsters
  - Sync temp HP changes across connected clients
- **components/combat-panel.tsx**: Removed player-only restriction from temp HP UI sections in both mobile and desktop views

## Test Plan

- [x] DMs can set temporary HP values for monsters during combat
- [x] Temp HP values are preserved in both monsters list and active combat participants
- [x] Temp HP syncs correctly across clients via emitHpChange
- [x] UI displays temp HP section for both player characters and monsters
- [x] Temp HP cannot be set to negative values (clamped to 0 or undefined)