### PR TITLE
fix: Allow robes (Vêtement type) to be equipped in armor slot

### DIFF
--- a/components/inventory-manager.tsx
+++ b/components/inventory-manager.tsx
@@ -300,19 +300,56 @@ export function InventoryManager({
 
   const toggleEquipped = (id: string) => {
     const item = localInventory.equipment.find(i => i.id === id)
+    if (!item) return
+
+    // If unequipping, just toggle off
+    if (item.equipped) {
+      const updatedInventory = {
+        ...localInventory,
+        equipment: localInventory.equipment.map(i =>
+          i.id === id ? { ...i, equipped: false, slot: null } : i
+        ),
+      }
+      setLocalInventory(updatedInventory)
+      onInventoryChange(updatedInventory)
+      return
+    }
 
     // If trying to equip an item that requires attunement, check limit
-    if (!item?.equipped && item?.requiresAttunement && attunedCount >= 3) {
+    if (item.requiresAttunement && attunedCount >= 3) {
       toast.warning("Vous avez déjà 3 objets harmonisés équipés", {
         description: "Déséquipez un objet harmonisé avant d'en équiper un autre."
       })
       return
     }
 
+    // If item has slotTypes, find first available slot and unequip existing item in that slot
+    if (item.slotTypes && item.slotTypes.length > 0) {
+      const targetSlot = item.slotTypes[0] // Use first compatible slot
+      const updatedInventory = {
+        ...localInventory,
+        equipment: localInventory.equipment.map(i => {
+          // Unequip the item currently in this slot
+          if (i.slot === targetSlot && i.id !== id) {
+            return { ...i, equipped: false, slot: null }
+          }
+          // Equip the selected item in this slot
+          if (i.id === id) {
+            return { ...i, equipped: true, slot: targetSlot }
+          }
+          return i
+        }),
+      }
+      setLocalInventory(updatedInventory)
+      onInventoryChange(updatedInventory)
+      return
+    }
+
+    // For items without slotTypes, just toggle equipped status
     const updatedInventory = {
       ...localInventory,
       equipment: localInventory.equipment.map(i =>
-        i.id === id ? { ...i, equipped: !i.equipped, slot: i.equipped ? null : i.slot } : i
+        i.id === id ? { ...i, equipped: true } : i
       ),
     }
     setLocalInventory(updatedInventory)

--- a/lib/notion-items.ts
+++ b/lib/notion-items.ts
@@ -354,8 +354,10 @@ async function mapNotionPageToCatalogItem(
         equipmentSlot = 'boots';
       } else if (typeLower.includes('gant') || typeLower === 'gloves') {
         equipmentSlot = 'gloves';
+      } else if (typeLower.includes('vêtement') || typeLower.includes('vetement')) {
+        // Vêtement/Vêtements (robes) are armor for spellcasters
+        equipmentSlot = 'armor';
       }
-      // Other magic objects (like capes, etc.) don't have a slot yet
     }
 
     // Extract image URL from cover


### PR DESCRIPTION
## Summary

This fix allows items of type "Vêtement" (robes) to be properly equipped in the armor slot on the character equipment silhouette. Additionally, the equipped toggle now correctly unequips the previously equipped item in the same slot when equipping a new item.

## Changes

### lib/notion-items.ts
- Added mapping for "Vêtement"/"Vêtement" item types to the "armor" equipment slot
- Robes are now recognized as armor equipment for spellcasters

### components/inventory-manager.tsx
- Refactored `toggleEquipped` function to properly handle slot-based equipment
- When equipping an item with a slot, the function now:
  - Automatically unequips any previously equipped item in that slot
  - Assigns the new item to its appropriate slot
- Improved logic to distinguish between unequipping and equipping actions
- Added null safety check for item lookup

## Testing

- Robes can now be equipped on the character equipment silhouette
- When equipping a new robe, any previously equipped robe is automatically unequipped
- The fix applies to all items with defined slot types (armor, boots, gloves, etc.)
- Attunement limit checking still works correctly

## Context

Spellcasters can now visually equip robes on their character sheet, improving the visual representation of their equipment loadout.