### PR TITLE
feat: Add DMG-2024 encounter generator with habitat filtering

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -225,6 +225,12 @@ hooks/                    # Custom React hooks
 
 ## Recent Work
 
+- **2026-08-19**: Encounter generator (`feature/encounter-generator` branch)
+  - DM-facing dialog to auto-compose a balanced encounter from the bestiary using the 2024 DMG XP-budget system: party size/level → difficulty tier (Faible/Modéré/Élevé/Mortel) → target XP, composition (Solo/Duo/Groupe/Horde) → monster count, creature-type dropdown filter, preview list with per-row reroll/remove before adding to combat in one batch
+  - Trigger moved from the top header into the "Préparation du Combat" card header (`Wand2` icon, next to the group-save `Dices` button)
+  - Habitat groundwork (this session): `monsters.habitat` (`TEXT[]`) + `habitat_options` lookup table, synced from Notion's `Habitat` multi-select — both the per-monster tags and the full option list (pulled from Notion's property schema, not just tagged monsters) refresh on every sync. `GET /api/monsters/habitats` exposes the option list. The actual habitat filter UI in the generator dialog is not yet built — pending the user finishing tagging monsters in Notion.
+  - Files: `lib/xp-difficulty.ts` (added `getTargetXpForTier`), `lib/encounter-generator.ts`, `components/encounter/generate-encounter-dialog.tsx`, `components/combat-setup-panel.tsx`, `app/page.tsx`, `lib/notion.ts` (`mapNotionMonsterToDbMonster` habitat extraction, `getHabitatOptionsFromNotion`), `lib/db.ts` (`Monster.habitat`, `getHabitatOptions`/`syncHabitatOptions`), `lib/monster-comparison.ts` (habitat added to sync diff), `app/api/notion/sync/apply/route.ts`, `app/api/monsters/habitats/route.ts`, `migrations/1787137112588_add-habitat-to-monsters.sql`
+
 - **2025-12-23**: Keyboard shortcuts system (`feat/keyboard-shortcuts` branch)
   - Global keyboard shortcuts for DM and player modes
   - Combat: Alt+S (start), Space (next turn), Alt+X (stop), Alt+R (roll initiatives)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,10 @@ Forme Éthérée. Peut traverser créatures et objets (1d10 force s'il termine d
 Ténacité Naine. Avantage aux JS contre Charmé et Effrayé.
 ```
 
+### Habitat Field
+
+`Habitat` is a Notion **multi-select** property (a monster can have several). Values are free-form — defined directly in Notion, no fixed list is hardcoded in the app. The app pulls the full set of configured options from Notion's property schema on every sync (so a brand-new option appears in the app immediately, even before any monster is tagged with it), separately from the per-monster tags themselves.
+
 ### Legendary Actions Field
 
 Same as Actions, but include cost in parentheses when > 1:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:24-alpine AS base
 
 # Install pnpm
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@10.34.5 --activate
 
 # Dependencies stage
 FROM base AS deps

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,7 +1,7 @@
 FROM node:24-alpine
 
 # Install pnpm
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@10.34.5 --activate
 
 WORKDIR /app
 

--- a/app/api/monsters/habitats/route.ts
+++ b/app/api/monsters/habitats/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+import { getHabitatOptions } from '@/lib/db';
+
+export async function GET() {
+  try {
+    const habitats = await getHabitatOptions();
+    return NextResponse.json(habitats);
+  } catch (error) {
+    console.error('Error fetching habitat options:', error);
+    return NextResponse.json({ error: 'Failed to fetch habitat options' }, { status: 500 });
+  }
+}

--- a/app/api/notion/sync/apply/route.ts
+++ b/app/api/notion/sync/apply/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from 'next/server';
-import { fetchMonstersFromNotion, mapNotionMonsterToDbMonster } from '@/lib/notion';
+import { fetchMonstersFromNotion, mapNotionMonsterToDbMonster, getHabitatOptionsFromNotion } from '@/lib/notion';
 import {
   updateMonsterFields,
   deleteMonstersById,
   upsertMonster,
+  syncHabitatOptions,
   type Monster
 } from '@/lib/db';
 
@@ -98,6 +99,17 @@ export async function POST(request: Request) {
           `Échec de l'ajout de "${add.name}": ${error instanceof Error ? error.message : 'Erreur inconnue'}`
         );
       }
+    }
+
+    // Phase 4: Refresh the full Habitat option list from Notion's property schema,
+    // so newly-added options are available in the app even before any monster uses them
+    try {
+      const habitatOptions = await getHabitatOptionsFromNotion();
+      await syncHabitatOptions(habitatOptions);
+    } catch (error) {
+      results.errors.push(
+        `Échec de la synchronisation des habitats: ${error instanceof Error ? error.message : 'Erreur inconnue'}`
+      );
     }
 
     console.log('Sync apply completed:', results);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,7 @@ import { LoadingSkeleton } from "@/components/loading-skeleton"
 import { toast } from "sonner"
 import { useSocketContext } from "@/lib/socket-context"
 import type { Character, Monster, CombatParticipant, DbMonster, CharacterInventory, ActiveBuff, Note } from "@/lib/types"
+import type { GeneratedEncounterRow } from "@/lib/encounter-generator"
 import { DEFAULT_INVENTORY } from "@/lib/types"
 import type { AmbientEffect } from "@/components/ambient-effects"
 import type { HistoryEntry } from "@/components/combat-history-panel"
@@ -38,6 +39,7 @@ const NotesPanel = dynamic(() => import("@/components/notes-panel").then(m => ({
 const AIAssistantPanel = dynamic(() => import("@/components/ai-assistant-panel").then(m => ({ default: m.AIAssistantPanel })), { ssr: false })
 const LootPanelConnected = dynamic(() => import("@/components/loot").then(m => ({ default: m.LootPanelConnected })), { loading: () => null })
 const LootDistributionSummaryDialog = dynamic(() => import("@/components/loot").then(m => ({ default: m.LootDistributionSummaryDialog })), { ssr: false })
+const GenerateEncounterDialog = dynamic(() => import("@/components/encounter/generate-encounter-dialog").then(m => ({ default: m.GenerateEncounterDialog })), { ssr: false })
 import {
   Dialog,
   DialogContent,
@@ -138,6 +140,7 @@ function CombatTrackerContent() {
 
   const [showHistory, setShowHistory] = useState(false)
   const [showSettings, setShowSettings] = useState(false)
+  const [showEncounterGenerator, setShowEncounterGenerator] = useState(false)
   const [showNotes, setShowNotes] = useState(false)
   // Keyboard shortcut dialog control
   const [keyboardConditionDialogOpen, setKeyboardConditionDialogOpen] = useState(false)
@@ -2487,6 +2490,50 @@ function CombatTrackerContent() {
     toast.success(`${quantity}x ${dbMonster.name} ajouté(s) au combat`)
   }
 
+  // Add a generated encounter (possibly several distinct monster types) to combat in one batch
+  const addEncounterToCombat = (rows: GeneratedEncounterRow[]) => {
+    const countByMonsterId = new Map<number, number>()
+    const newParticipants: CombatParticipant[] = rows.map((row, i) => {
+      const seen = (countByMonsterId.get(row.monster.id) || 0) + 1
+      countByMonsterId.set(row.monster.id, seen)
+      const totalOfType = rows.filter(r => r.monster.id === row.monster.id).length
+      return {
+        id: `enc-${row.monster.id}-${Date.now()}-${i}`,
+        name: totalOfType > 1 ? `${row.monster.name} ${seen}` : row.monster.name,
+        initiative: Math.floor(Math.random() * 20) + 1,
+        currentHp: row.monster.hit_points || 10,
+        maxHp: row.monster.hit_points || 10,
+        ac: row.monster.armor_class || undefined,
+        conditions: [],
+        exhaustionLevel: 0,
+        buffs: [],
+        type: "monster",
+        xp: row.monster.challenge_rating_xp || undefined,
+      }
+    })
+
+    setCombatParticipants(prev => {
+      const updated = sortParticipantsByInitiative([...prev, ...newParticipants])
+
+      if (combatActive) {
+        queueMicrotask(() => {
+          emitCombatUpdate({
+            type: 'state-sync',
+            combatActive: true,
+            currentTurn,
+            roundNumber,
+            participants: updated,
+          })
+        })
+      }
+
+      return updated
+    })
+
+    const totalXp = newParticipants.reduce((sum, p) => sum + (p.xp || 0), 0)
+    toast.success(`Rencontre ajoutée : ${newParticipants.length} monstre(s), ${totalXp} XP`)
+  }
+
   // Add session monsters to combat with quantity (for mobile tap-to-add)
   const addSessionMonstersToCombat = (monster: Monster, quantity: number) => {
     const newParticipants: CombatParticipant[] = Array.from({ length: quantity }, (_, i) => ({
@@ -3025,6 +3072,7 @@ function CombatTrackerContent() {
                   ownCharacterIds={selectedCharacters.map(c => String(c.id))}
                   connectedPlayerIds={displayPlayers.filter(p => p.isConnected).map(p => p.id)}
                   onGroupSave={() => setShowGroupSaveConfig(true)}
+                  onGenerateEncounter={() => setShowEncounterGenerator(true)}
                 />
               )}
               {activeTab === "bestiary" && mode === "mj" && (
@@ -3252,6 +3300,7 @@ function CombatTrackerContent() {
                     ownCharacterIds={selectedCharacters.map(c => String(c.id))}
                     connectedPlayerIds={displayPlayers.filter(p => p.isConnected).map(p => p.id)}
                     onGroupSave={() => setShowGroupSaveConfig(true)}
+                    onGenerateEncounter={() => setShowEncounterGenerator(true)}
                   />
                 </div>
 
@@ -3296,6 +3345,15 @@ function CombatTrackerContent() {
         onCampaignNameChange={setCampaignName}
         onMonsterSyncComplete={() => setMonsterRefreshKey(k => k + 1)}
       />
+
+      {/* Encounter Generator - MJ only */}
+      {mode === "mj" && (
+        <GenerateEncounterDialog
+          isOpen={showEncounterGenerator}
+          onClose={() => setShowEncounterGenerator(false)}
+          onConfirm={addEncounterToCombat}
+        />
+      )}
 
       {/* Session Notes Panel - MJ only */}
       {mode === "mj" && (

--- a/components/combat-setup-panel.tsx
+++ b/components/combat-setup-panel.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react"
 import { useDroppable } from "@dnd-kit/core"
-import { Swords, Play, Users, Skull, ArrowDown, Dices, Save, FolderOpen, Trash2, Loader2, MousePointer, AlertTriangle, WifiOff } from "lucide-react"
+import { Swords, Play, Users, Skull, ArrowDown, Dices, Wand2, Save, FolderOpen, Trash2, Loader2, MousePointer, AlertTriangle, WifiOff } from "lucide-react"
 import { useIsMobile } from "@/components/ui/use-mobile"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
@@ -84,6 +84,7 @@ interface CombatSetupPanelProps {
   ownCharacterIds?: string[] // IDs of characters owned by the current player
   connectedPlayerIds?: string[] // IDs of currently connected players
   onGroupSave?: () => void // Callback to trigger group save dialog
+  onGenerateEncounter?: () => void // Callback to trigger the encounter generator dialog
 }
 
 export function CombatSetupPanel({
@@ -99,6 +100,7 @@ export function CombatSetupPanel({
   ownCharacterIds = [],
   connectedPlayerIds = [],
   onGroupSave,
+  onGenerateEncounter,
 }: CombatSetupPanelProps) {
   const isMobile = useIsMobile()
   const { combatParticipants, isOverCombatZone } = useCombatDnd()
@@ -329,6 +331,17 @@ export function CombatSetupPanel({
                   </Badge>
                 )}
               </>
+            )}
+            {mode === "mj" && onGenerateEncounter && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={onGenerateEncounter}
+                className="h-7 px-2 border-crimson/30 hover:border-crimson hover:bg-crimson/10 text-crimson"
+                title="Générer une rencontre"
+              >
+                <Wand2 className="w-4 h-4" />
+              </Button>
             )}
             {mode === "mj" && onGroupSave && (
               <Button

--- a/components/encounter/generate-encounter-dialog.tsx
+++ b/components/encounter/generate-encounter-dialog.tsx
@@ -1,0 +1,377 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Badge } from "@/components/ui/badge"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Swords, RefreshCw, Trash2, Loader2, AlertTriangle, ArrowLeft } from "lucide-react"
+import { cn } from "@/lib/utils"
+import type { DbMonster } from "@/lib/types"
+import {
+  calculateDifficulty,
+  getTargetXpForTier,
+  DIFFICULTY_LABELS,
+  DIFFICULTY_COLORS,
+  type GenerationDifficultyTier,
+} from "@/lib/xp-difficulty"
+import {
+  COMPOSITION_CONFIG,
+  filterBestiaryByCreatureType,
+  filterBestiaryByHabitat,
+  generateEncounter,
+  regenerateRow,
+  type EncounterComposition,
+  type GeneratedEncounterRow,
+} from "@/lib/encounter-generator"
+
+interface GenerateEncounterDialogProps {
+  isOpen: boolean
+  onClose: () => void
+  onConfirm: (rows: GeneratedEncounterRow[]) => void
+}
+
+const TIERS: { value: GenerationDifficultyTier }[] = [
+  { value: 'low' },
+  { value: 'moderate' },
+  { value: 'high' },
+  { value: 'deadly' },
+]
+
+const COMPOSITIONS: EncounterComposition[] = ['solo', 'duo', 'group', 'mob']
+
+export function GenerateEncounterDialog({ isOpen, onClose, onConfirm }: GenerateEncounterDialogProps) {
+  const [step, setStep] = useState<'params' | 'preview'>('params')
+
+  const [partySize, setPartySize] = useState(4)
+  const [partyLevel, setPartyLevel] = useState(1)
+  const [tier, setTier] = useState<GenerationDifficultyTier>('moderate')
+  const [composition, setComposition] = useState<EncounterComposition>('group')
+  const [monsterCount, setMonsterCount] = useState(COMPOSITION_CONFIG.group.defaultCount)
+  const [creatureTypeFilter, setCreatureTypeFilter] = useState('all')
+  const [habitatFilter, setHabitatFilter] = useState('all')
+
+  const [bestiary, setBestiary] = useState<DbMonster[]>([])
+  const [bestiaryLoading, setBestiaryLoading] = useState(true)
+  const [habitatOptions, setHabitatOptions] = useState<string[]>([])
+
+  const creatureTypes = useMemo(
+    () => [...new Set(bestiary.map(m => m.creature_type).filter((t): t is string => !!t))].sort(),
+    [bestiary]
+  )
+  const [paramsError, setParamsError] = useState<string | null>(null)
+
+  const [players, setPlayers] = useState<{ level: number }[]>([])
+  const [candidates, setCandidates] = useState<DbMonster[]>([])
+  const [rows, setRows] = useState<GeneratedEncounterRow[]>([])
+  const [targetXp, setTargetXp] = useState(0)
+  const [isBestEffort, setIsBestEffort] = useState(false)
+
+  useEffect(() => {
+    if (!isOpen) return
+    let cancelled = false
+    async function fetchBestiary() {
+      try {
+        setBestiaryLoading(true)
+        const response = await fetch("/api/monsters")
+        if (!response.ok) throw new Error("Failed to fetch monsters")
+        const data = await response.json()
+        if (!cancelled) setBestiary(data)
+      } catch {
+        if (!cancelled) setParamsError("Impossible de charger le bestiaire.")
+      } finally {
+        if (!cancelled) setBestiaryLoading(false)
+      }
+    }
+    async function fetchHabitatOptions() {
+      try {
+        const response = await fetch("/api/monsters/habitats")
+        if (!response.ok) throw new Error("Failed to fetch habitats")
+        const data = await response.json()
+        if (!cancelled) setHabitatOptions(data)
+      } catch {
+        // Non-critical: habitat filter simply stays empty (only "Tous les habitats")
+      }
+    }
+    fetchBestiary()
+    fetchHabitatOptions()
+    return () => { cancelled = true }
+  }, [isOpen])
+
+  const handleCompositionChange = (value: EncounterComposition) => {
+    setComposition(value)
+    setMonsterCount(COMPOSITION_CONFIG[value].defaultCount)
+  }
+
+  const handleGenerate = () => {
+    const partyPlayers = Array.from({ length: partySize }, () => ({ level: partyLevel }))
+    const byType = filterBestiaryByCreatureType(bestiary, creatureTypeFilter === 'all' ? '' : creatureTypeFilter)
+    const filtered = filterBestiaryByHabitat(byType, habitatFilter === 'all' ? '' : habitatFilter)
+    if (filtered.length === 0) {
+      setParamsError("Aucun monstre ne correspond à ces filtres de type/habitat.")
+      return
+    }
+    setParamsError(null)
+    const target = getTargetXpForTier(tier, partyPlayers)
+    const result = generateEncounter({ targetXp: target, monsterCount, candidates: filtered })
+    setPlayers(partyPlayers)
+    setCandidates(filtered)
+    setRows(result.rows)
+    setTargetXp(result.targetXp)
+    setIsBestEffort(result.isBestEffort)
+    setStep('preview')
+  }
+
+  const handleRerollRow = (id: string) => {
+    setRows(prev => prev.map(row => row.id === id ? regenerateRow(row, candidates) : row))
+  }
+
+  const handleRemoveRow = (id: string) => {
+    setRows(prev => prev.filter(row => row.id !== id))
+  }
+
+  const handleConfirm = () => {
+    onConfirm(rows)
+    handleClose()
+  }
+
+  const handleClose = () => {
+    setStep('params')
+    setRows([])
+    setParamsError(null)
+    onClose()
+  }
+
+  const totalXp = rows.reduce((sum, row) => sum + (row.monster.challenge_rating_xp || 0), 0)
+  const achievedTier = rows.length > 0 ? calculateDifficulty(totalXp, players) : null
+  const anyOffTolerance = isBestEffort || rows.some(row => !row.withinTolerance)
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Swords className="h-5 w-5" />
+            Générer une rencontre
+          </DialogTitle>
+          <DialogDescription>
+            Composez une rencontre équilibrée à partir du bestiaire, selon le budget XP (DMG 2024).
+          </DialogDescription>
+        </DialogHeader>
+
+        {step === 'params' && (
+          <div className="space-y-6 py-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="party-size">Nombre de joueurs</Label>
+                <Input
+                  id="party-size"
+                  type="number"
+                  min={1}
+                  max={10}
+                  value={partySize}
+                  onChange={(e) => setPartySize(Math.max(1, Math.min(10, parseInt(e.target.value) || 1)))}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="party-level">Niveau moyen</Label>
+                <Input
+                  id="party-level"
+                  type="number"
+                  min={1}
+                  max={20}
+                  value={partyLevel}
+                  onChange={(e) => setPartyLevel(Math.max(1, Math.min(20, parseInt(e.target.value) || 1)))}
+                />
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <Label className="text-sm font-medium">Difficulté</Label>
+              <RadioGroup
+                value={tier}
+                onValueChange={(value) => setTier(value as GenerationDifficultyTier)}
+                className="grid grid-cols-2 gap-2"
+              >
+                {TIERS.map((t) => (
+                  <div key={t.value} className="flex items-center space-x-2">
+                    <RadioGroupItem value={t.value} id={`tier-${t.value}`} />
+                    <Label htmlFor={`tier-${t.value}`} className="cursor-pointer">
+                      {DIFFICULTY_LABELS[t.value]}
+                    </Label>
+                  </div>
+                ))}
+              </RadioGroup>
+            </div>
+
+            <div className="space-y-3">
+              <Label className="text-sm font-medium">Composition</Label>
+              <RadioGroup
+                value={composition}
+                onValueChange={(value) => handleCompositionChange(value as EncounterComposition)}
+                className="space-y-2"
+              >
+                {COMPOSITIONS.map((c) => (
+                  <div key={c} className="flex items-center space-x-2">
+                    <RadioGroupItem value={c} id={`comp-${c}`} />
+                    <Label htmlFor={`comp-${c}`} className="flex flex-col cursor-pointer">
+                      <span className="font-medium">{COMPOSITION_CONFIG[c].label}</span>
+                      <span className="text-xs text-muted-foreground">{COMPOSITION_CONFIG[c].description}</span>
+                    </Label>
+                  </div>
+                ))}
+              </RadioGroup>
+            </div>
+
+            {COMPOSITION_CONFIG[composition].minCount !== COMPOSITION_CONFIG[composition].maxCount && (
+              <div className="space-y-2">
+                <Label htmlFor="monster-count">Nombre de monstres</Label>
+                <Input
+                  id="monster-count"
+                  type="number"
+                  min={COMPOSITION_CONFIG[composition].minCount}
+                  max={COMPOSITION_CONFIG[composition].maxCount}
+                  value={monsterCount}
+                  onChange={(e) => {
+                    const { minCount, maxCount } = COMPOSITION_CONFIG[composition]
+                    setMonsterCount(Math.max(minCount, Math.min(maxCount, parseInt(e.target.value) || minCount)))
+                  }}
+                  className="w-24"
+                />
+              </div>
+            )}
+
+            <div className="space-y-2">
+              <Label htmlFor="creature-type">Type de créature</Label>
+              <Select value={creatureTypeFilter} onValueChange={setCreatureTypeFilter}>
+                <SelectTrigger id="creature-type" className="w-full">
+                  <SelectValue placeholder="Type de créature" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">Tous les types</SelectItem>
+                  {creatureTypes.map((type) => (
+                    <SelectItem key={type} value={type}>{type}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="habitat">Habitat</Label>
+              <Select value={habitatFilter} onValueChange={setHabitatFilter}>
+                <SelectTrigger id="habitat" className="w-full">
+                  <SelectValue placeholder="Habitat" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">Tous les habitats</SelectItem>
+                  {habitatOptions.map((habitat) => (
+                    <SelectItem key={habitat} value={habitat}>{habitat}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {paramsError && (
+              <p className="text-sm text-destructive flex items-center gap-2">
+                <AlertTriangle className="h-4 w-4" />
+                {paramsError}
+              </p>
+            )}
+          </div>
+        )}
+
+        {step === 'preview' && (
+          <div className="space-y-4 py-4">
+            <div className="flex items-center justify-between rounded-md border p-3">
+              <div className="text-sm">
+                <div className="text-muted-foreground">Budget cible : {targetXp} XP</div>
+                <div className="font-medium">Total actuel : {totalXp} XP</div>
+              </div>
+              {achievedTier && (
+                <Badge variant="outline" className={cn("text-xs", DIFFICULTY_COLORS[achievedTier])}>
+                  {DIFFICULTY_LABELS[achievedTier]}
+                </Badge>
+              )}
+            </div>
+
+            {(anyOffTolerance || achievedTier !== tier) && (
+              <p className="text-sm text-amber-500 flex items-center gap-2">
+                <AlertTriangle className="h-4 w-4 shrink-0" />
+                Meilleur effort : le bestiaire ne contient pas de monstre proche du budget pour certains emplacements.
+              </p>
+            )}
+
+            <ScrollArea className="h-72 rounded-md border">
+              <div className="divide-y">
+                {rows.length === 0 && (
+                  <p className="p-4 text-sm text-muted-foreground">Aucun monstre dans cette rencontre.</p>
+                )}
+                {rows.map((row) => (
+                  <div key={row.id} className="flex items-center justify-between gap-2 p-3">
+                    <div className="min-w-0">
+                      <div className="font-medium truncate">{row.monster.name}</div>
+                      <div className="text-xs text-muted-foreground">
+                        PV {row.monster.hit_points ?? '?'} · CA {row.monster.armor_class ?? '?'} · {row.monster.challenge_rating_xp ?? 0} XP
+                        {!row.withinTolerance && <span className="text-amber-500"> (approx.)</span>}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-1 shrink-0">
+                      <Button variant="ghost" size="icon" onClick={() => handleRerollRow(row.id)} title="Relancer">
+                        <RefreshCw className="h-4 w-4" />
+                      </Button>
+                      <Button variant="ghost" size="icon" onClick={() => handleRemoveRow(row.id)} title="Retirer">
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </ScrollArea>
+          </div>
+        )}
+
+        <DialogFooter className="gap-2">
+          {step === 'params' ? (
+            <>
+              <Button variant="outline" onClick={handleClose}>Annuler</Button>
+              <Button onClick={handleGenerate} disabled={bestiaryLoading}>
+                {bestiaryLoading ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    Chargement...
+                  </>
+                ) : (
+                  <>
+                    <Swords className="h-4 w-4 mr-2" />
+                    Générer
+                  </>
+                )}
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button variant="outline" onClick={() => setStep('params')}>
+                <ArrowLeft className="h-4 w-4 mr-2" />
+                Retour
+              </Button>
+              <Button onClick={handleConfirm} disabled={rows.length === 0}>
+                Ajouter au combat
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -56,6 +56,7 @@ export interface Monster {
   image_url: string | null;
   ai_generated: string | null;  // AI-generated image path (local only)
   notion_id: string | null;      // Notion page ID (for sync tracking)
+  habitat: string[];             // Habitats this monster can appear in, from Notion's Habitat multi-select
   created_at: Date;
 }
 
@@ -214,8 +215,8 @@ export async function upsertMonster(monster: Omit<Monster, 'id' | 'created_at'>)
       intelligence, wisdom, charisma, strength_mod, dexterity_mod, constitution_mod,
       intelligence_mod, wisdom_mod, charisma_mod, creature_type, size,
       challenge_rating_xp, actions, bonus_actions, reactions, legendary_actions, traits,
-      description, image_url, notion_id, ai_generated
-    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28)
+      description, image_url, notion_id, ai_generated, habitat
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29)
     ON CONFLICT (name)
     DO UPDATE SET
       armor_class = EXCLUDED.armor_class,
@@ -243,7 +244,8 @@ export async function upsertMonster(monster: Omit<Monster, 'id' | 'created_at'>)
       traits = EXCLUDED.traits,
       description = EXCLUDED.description,
       image_url = EXCLUDED.image_url,
-      notion_id = EXCLUDED.notion_id
+      notion_id = EXCLUDED.notion_id,
+      habitat = EXCLUDED.habitat
       -- NOTE: ai_generated is NOT updated here, preserving local AI-generated images
     RETURNING *`,
     [
@@ -284,9 +286,35 @@ export async function upsertMonster(monster: Omit<Monster, 'id' | 'created_at'>)
       monster.image_url,
       monster.notion_id || null,
       monster.ai_generated || null,
+      monster.habitat || [],
     ]
   );
   return result.rows[0];
+}
+
+export async function getHabitatOptions(): Promise<string[]> {
+  const result = await pool.query('SELECT name FROM habitat_options ORDER BY name');
+  return result.rows.map(row => row.name);
+}
+
+export async function syncHabitatOptions(names: string[]): Promise<void> {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query('DELETE FROM habitat_options');
+    if (names.length > 0) {
+      await client.query(
+        'INSERT INTO habitat_options (name) SELECT unnest($1::text[]) ON CONFLICT DO NOTHING',
+        [names]
+      );
+    }
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
 }
 
 // Campaign types and functions

--- a/lib/encounter-generator.ts
+++ b/lib/encounter-generator.ts
@@ -1,0 +1,137 @@
+/**
+ * Encounter Generator
+ * Picks real bestiary monsters that fit an XP budget, given a target XP
+ * and an encounter "composition" (monster count shape).
+ */
+
+import type { DbMonster } from './types'
+
+// ============================================
+// Types
+// ============================================
+
+export type EncounterComposition = 'solo' | 'duo' | 'group' | 'mob'
+
+export interface GeneratedEncounterRow {
+  id: string
+  monster: DbMonster
+  targetShareXp: number
+  withinTolerance: boolean
+}
+
+export interface GeneratedEncounterResult {
+  rows: GeneratedEncounterRow[]
+  targetXp: number
+  totalXp: number
+  isBestEffort: boolean
+}
+
+// ============================================
+// Composition config
+// ============================================
+
+export const COMPOSITION_CONFIG: Record<EncounterComposition, {
+  label: string
+  description: string
+  minCount: number
+  maxCount: number
+  defaultCount: number
+}> = {
+  solo: {
+    label: 'Solo (boss unique)',
+    description: 'Un monstre unique absorbe tout le budget',
+    minCount: 1,
+    maxCount: 1,
+    defaultCount: 1,
+  },
+  duo: {
+    label: 'Duo élite',
+    description: 'Deux monstres puissants se partagent le budget',
+    minCount: 2,
+    maxCount: 2,
+    defaultCount: 2,
+  },
+  group: {
+    label: 'Groupe standard',
+    description: '3 à 5 monstres de force comparable',
+    minCount: 3,
+    maxCount: 5,
+    defaultCount: 4,
+  },
+  mob: {
+    label: 'Horde',
+    description: '6 à 12 monstres faibles, nombreux',
+    minCount: 6,
+    maxCount: 12,
+    defaultCount: 8,
+  },
+}
+
+// ============================================
+// Selection
+// ============================================
+
+const TOLERANCE_BANDS = [0.15, 0.30, 0.50]
+
+export function filterBestiaryByCreatureType(bestiary: DbMonster[], typeFilter: string): DbMonster[] {
+  const pool = bestiary.filter(m => m.challenge_rating_xp != null && m.challenge_rating_xp > 0)
+  const q = typeFilter.trim().toLowerCase()
+  if (!q) return pool
+  return pool.filter(m => m.creature_type?.toLowerCase() === q)
+}
+
+export function filterBestiaryByHabitat(bestiary: DbMonster[], habitatFilter: string): DbMonster[] {
+  const q = habitatFilter.trim().toLowerCase()
+  if (!q) return bestiary
+  return bestiary.filter(m => m.habitat?.some(h => h.toLowerCase() === q))
+}
+
+function pickMonsterNear(target: number, candidates: DbMonster[]): { monster: DbMonster; withinTolerance: boolean } {
+  for (const tolerance of TOLERANCE_BANDS) {
+    const lo = target * (1 - tolerance)
+    const hi = target * (1 + tolerance)
+    const inBand = candidates.filter(m => {
+      const xp = m.challenge_rating_xp as number
+      return xp >= lo && xp <= hi
+    })
+    if (inBand.length > 0) {
+      const chosen = inBand[Math.floor(Math.random() * inBand.length)]
+      return { monster: chosen, withinTolerance: tolerance <= 0.30 }
+    }
+  }
+
+  const closest = candidates.reduce((best, m) =>
+    Math.abs((m.challenge_rating_xp as number) - target) < Math.abs((best.challenge_rating_xp as number) - target) ? m : best
+  )
+  return { monster: closest, withinTolerance: false }
+}
+
+export function generateEncounter(params: {
+  targetXp: number
+  monsterCount: number
+  candidates: DbMonster[]
+}): GeneratedEncounterResult {
+  if (params.candidates.length === 0) {
+    throw new Error('Aucun monstre disponible dans le bestiaire pour ce filtre')
+  }
+
+  const perMonsterTarget = params.targetXp / params.monsterCount
+  const rows: GeneratedEncounterRow[] = Array.from({ length: params.monsterCount }, () => {
+    const { monster, withinTolerance } = pickMonsterNear(perMonsterTarget, params.candidates)
+    return { id: crypto.randomUUID(), monster, targetShareXp: perMonsterTarget, withinTolerance }
+  })
+
+  const totalXp = rows.reduce((sum, row) => sum + (row.monster.challenge_rating_xp || 0), 0)
+
+  return {
+    rows,
+    targetXp: params.targetXp,
+    totalXp,
+    isBestEffort: rows.some(row => !row.withinTolerance),
+  }
+}
+
+export function regenerateRow(row: GeneratedEncounterRow, candidates: DbMonster[]): GeneratedEncounterRow {
+  const { monster, withinTolerance } = pickMonsterNear(row.targetShareXp, candidates)
+  return { ...row, monster, withinTolerance }
+}

--- a/lib/monster-comparison.ts
+++ b/lib/monster-comparison.ts
@@ -71,6 +71,7 @@ export const FIELD_LABELS: Record<string, string> = {
   legendary_actions: 'Actions légendaires',
   traits: 'Traits',
   image_url: 'Image URL',
+  habitat: 'Habitat',
 };
 
 /**
@@ -166,6 +167,7 @@ export function compareMonsters(
     'legendary_actions',
     'traits',
     'image_url',
+    'habitat',
   ];
 
   for (const field of fieldsToCompare) {
@@ -173,7 +175,7 @@ export function compareMonsters(
     const newValue = normalizeValue(notionMonster[field]);
 
     let hasChanged = false;
-    const isJsonb = field === 'actions' || field === 'legendary_actions' || field === 'traits';
+    const isJsonb = field === 'actions' || field === 'legendary_actions' || field === 'traits' || field === 'habitat';
 
     if (isJsonb) {
       hasChanged = !areJsonEqual(oldValue, newValue);

--- a/lib/notion.ts
+++ b/lib/notion.ts
@@ -531,6 +531,9 @@ export function mapNotionMonsterToDbMonster(notionMonster: any): Partial<Monster
   // Description (flavor text)
   const description = extractStringProp(props.Description) || null;
 
+  // Habitats this monster can appear in (multi-select)
+  const habitat = parseCommaSeparated(extractMultiSelect(props.Habitat));
+
   // Extract actions - handles both array (new) and rich_text (old) formats
   const actions = extractActions(props.Actions);
   const bonus_actions = extractActions(props['Actions Bonus']);
@@ -580,7 +583,27 @@ export function mapNotionMonsterToDbMonster(notionMonster: any): Partial<Monster
     traits,
     description,
     image_url,
+    habitat,
   };
+}
+
+/**
+ * Fetch the full list of configured Habitat multi-select options from the
+ * Notion database schema, independent of which monsters currently use them.
+ */
+export async function getHabitatOptionsFromNotion(): Promise<string[]> {
+  const notion = getNotionClient();
+  const databaseId = getDatabaseId();
+  const dataSourceId = await getDataSourceId(notion, databaseId);
+
+  const dataSource = await notion.dataSources.retrieve({ data_source_id: dataSourceId }) as any;
+  const habitatProp = dataSource.properties?.Habitat;
+
+  if (!habitatProp || habitatProp.type !== 'multi_select') {
+    return [];
+  }
+
+  return habitatProp.multi_select.options.map((option: any) => option.name);
 }
 
 /**

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -250,6 +250,7 @@ export interface DbMonster {
   image_url: string | null
   ai_generated: string | null
   notion_id: string | null
+  habitat: string[]
 }
 
 // Condition definition with icon and color

--- a/lib/xp-difficulty.ts
+++ b/lib/xp-difficulty.ts
@@ -111,6 +111,32 @@ export function calculateDifficulty(
   return 'low'
 }
 
+// Generation only supports non-trivial tiers: calculateDifficulty only ever
+// returns 'trivial' when totalXp === 0, so it can never be a meaningful generation target.
+export type GenerationDifficultyTier = Exclude<DifficultyTier, 'trivial'>
+
+/**
+ * Inverse of calculateDifficulty: given a desired tier, return a target total
+ * monster XP that lands inside that tier's band (not on a boundary, since
+ * calculateDifficulty's >= comparisons make boundary values ambiguous).
+ */
+export function getTargetXpForTier(
+  tier: GenerationDifficultyTier,
+  players: { level: number }[]
+): number {
+  const { low, moderate, high } = getPartyXPBudget(players)
+  switch (tier) {
+    case 'low':
+      return Math.round(low * 0.6)
+    case 'moderate':
+      return Math.round((low + moderate) / 2)
+    case 'high':
+      return Math.round((moderate + high) / 2)
+    case 'deadly':
+      return Math.round(high * 1.25)
+  }
+}
+
 /**
  * Get the XP thresholds for a party (for UI display)
  * Returns the actual XP values for each difficulty tier

--- a/migrations/1787137112588_add-habitat-to-monsters.sql
+++ b/migrations/1787137112588_add-habitat-to-monsters.sql
@@ -1,0 +1,8 @@
+-- Add habitat multi-value column to monsters, synced from Notion's Habitat multi-select property
+ALTER TABLE monsters ADD COLUMN IF NOT EXISTS habitat TEXT[] DEFAULT '{}';
+
+-- Lookup table of all Habitat options configured in Notion, refreshed on every sync
+-- so new options are available in the app even before any monster is tagged with them
+CREATE TABLE IF NOT EXISTS habitat_options (
+    name TEXT PRIMARY KEY
+);

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "my-v0-project",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@10.34.5",
   "scripts": {
     "build": "next build",
     "dev": "tsx watch server.ts",


### PR DESCRIPTION
## Summary
- DM-facing "Générer une rencontre" dialog (triggered from the "Préparation du Combat" panel) that composes a balanced encounter from the bestiary using the 2024 DMG XP-budget system: party size/level → difficulty tier → target XP, composition (Solo/Duo/Groupe/Horde) → monster count/spread, with creature-type and habitat dropdown filters, then a reviewable preview (per-row reroll/remove) before adding to combat in one batch.
- Habitat data pipeline: `monsters.habitat` + `habitat_options`, synced from Notion's `Habitat` multi-select property — both per-monster tags and the full configured option list (from Notion's schema, not just tagged monsters) refresh on every sync.
- Infra fix: pinned pnpm to `10.34.5` in both Dockerfiles + `package.json` — corepack's `pnpm@latest` (11.x) was crash-looping `pnpm migrate`/`pnpm dev` via a broken pre-run deps-status-check.

## Test plan
- [x] `tsc --noEmit` in the dev container shows zero new errors from this change
- [x] `docker-compose -f docker-compose.dev.yml up --build` starts cleanly, no restart loop (confirms the pnpm pin fix)
- [x] Functional smoke tests of `generateEncounter`/`getTargetXpForTier`/`filterBestiaryByCreatureType`/`filterBestiaryByHabitat` against the live bestiary (75 real monsters) — correct XP-budget math, tolerance-fallback behavior, exact-match type/habitat filtering
- [x] Reproduced and fixed a real bug (random monster selection when nothing was close to budget) before merge
- [x] Ran a real Notion sync end-to-end via `/api/notion/sync/preview` + `/api/notion/sync/apply` — confirmed `habitat`/`habitat_options` sync correctly, including a mid-session repair after a test script accidentally overwrote live habitat data (fixed via re-sync, not manual data entry)
- [ ] Manual click-through of the dialog in a browser (not verified visually this session — browser tooling in this environment isn't network-reachable to the local dev container)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
