### PR TITLE
feat: Allow multi-select creature type and habitat filters in encounter generator

### DIFF
--- a/components/encounter/generate-encounter-dialog.tsx
+++ b/components/encounter/generate-encounter-dialog.tsx
@@ -15,8 +15,8 @@ import { Label } from "@/components/ui/label"
 import { Badge } from "@/components/ui/badge"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Swords, RefreshCw, Trash2, Loader2, AlertTriangle, ArrowLeft } from "lucide-react"
+import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuCheckboxItem } from "@/components/ui/dropdown-menu"
+import { Swords, RefreshCw, Trash2, Loader2, AlertTriangle, ArrowLeft, ChevronDown } from "lucide-react"
 import { cn } from "@/lib/utils"
 import type { DbMonster } from "@/lib/types"
 import {
@@ -51,6 +51,16 @@ const TIERS: { value: GenerationDifficultyTier }[] = [
 
 const COMPOSITIONS: EncounterComposition[] = ['solo', 'duo', 'group', 'mob']
 
+function toggleInArray(values: string[], value: string): string[] {
+  return values.includes(value) ? values.filter(v => v !== value) : [...values, value]
+}
+
+function summarizeSelection(values: string[], allLabel: string, unit: string): string {
+  if (values.length === 0) return allLabel
+  if (values.length <= 2) return values.join(", ")
+  return `${values.length} ${unit} sélectionnés`
+}
+
 export function GenerateEncounterDialog({ isOpen, onClose, onConfirm }: GenerateEncounterDialogProps) {
   const [step, setStep] = useState<'params' | 'preview'>('params')
 
@@ -59,8 +69,8 @@ export function GenerateEncounterDialog({ isOpen, onClose, onConfirm }: Generate
   const [tier, setTier] = useState<GenerationDifficultyTier>('moderate')
   const [composition, setComposition] = useState<EncounterComposition>('group')
   const [monsterCount, setMonsterCount] = useState(COMPOSITION_CONFIG.group.defaultCount)
-  const [creatureTypeFilter, setCreatureTypeFilter] = useState('all')
-  const [habitatFilter, setHabitatFilter] = useState('all')
+  const [creatureTypeFilters, setCreatureTypeFilters] = useState<string[]>([])
+  const [habitatFilters, setHabitatFilters] = useState<string[]>([])
 
   const [bestiary, setBestiary] = useState<DbMonster[]>([])
   const [bestiaryLoading, setBestiaryLoading] = useState(true)
@@ -116,8 +126,8 @@ export function GenerateEncounterDialog({ isOpen, onClose, onConfirm }: Generate
 
   const handleGenerate = () => {
     const partyPlayers = Array.from({ length: partySize }, () => ({ level: partyLevel }))
-    const byType = filterBestiaryByCreatureType(bestiary, creatureTypeFilter === 'all' ? '' : creatureTypeFilter)
-    const filtered = filterBestiaryByHabitat(byType, habitatFilter === 'all' ? '' : habitatFilter)
+    const byType = filterBestiaryByCreatureType(bestiary, creatureTypeFilters)
+    const filtered = filterBestiaryByHabitat(byType, habitatFilters)
     if (filtered.length === 0) {
       setParamsError("Aucun monstre ne correspond à ces filtres de type/habitat.")
       return
@@ -254,32 +264,50 @@ export function GenerateEncounterDialog({ isOpen, onClose, onConfirm }: Generate
 
             <div className="space-y-2">
               <Label htmlFor="creature-type">Type de créature</Label>
-              <Select value={creatureTypeFilter} onValueChange={setCreatureTypeFilter}>
-                <SelectTrigger id="creature-type" className="w-full">
-                  <SelectValue placeholder="Type de créature" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">Tous les types</SelectItem>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button id="creature-type" variant="outline" className="w-full justify-between font-normal">
+                    {summarizeSelection(creatureTypeFilters, "Tous les types", "types")}
+                    <ChevronDown className="h-4 w-4 opacity-50" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent className="w-[--radix-dropdown-menu-trigger-width] max-h-72 overflow-y-auto">
                   {creatureTypes.map((type) => (
-                    <SelectItem key={type} value={type}>{type}</SelectItem>
+                    <DropdownMenuCheckboxItem
+                      key={type}
+                      checked={creatureTypeFilters.includes(type)}
+                      onSelect={(e) => e.preventDefault()}
+                      onCheckedChange={() => setCreatureTypeFilters(prev => toggleInArray(prev, type))}
+                    >
+                      {type}
+                    </DropdownMenuCheckboxItem>
                   ))}
-                </SelectContent>
-              </Select>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
 
             <div className="space-y-2">
               <Label htmlFor="habitat">Habitat</Label>
-              <Select value={habitatFilter} onValueChange={setHabitatFilter}>
-                <SelectTrigger id="habitat" className="w-full">
-                  <SelectValue placeholder="Habitat" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">Tous les habitats</SelectItem>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button id="habitat" variant="outline" className="w-full justify-between font-normal">
+                    {summarizeSelection(habitatFilters, "Tous les habitats", "habitats")}
+                    <ChevronDown className="h-4 w-4 opacity-50" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent className="w-[--radix-dropdown-menu-trigger-width] max-h-72 overflow-y-auto">
                   {habitatOptions.map((habitat) => (
-                    <SelectItem key={habitat} value={habitat}>{habitat}</SelectItem>
+                    <DropdownMenuCheckboxItem
+                      key={habitat}
+                      checked={habitatFilters.includes(habitat)}
+                      onSelect={(e) => e.preventDefault()}
+                      onCheckedChange={() => setHabitatFilters(prev => toggleInArray(prev, habitat))}
+                    >
+                      {habitat}
+                    </DropdownMenuCheckboxItem>
                   ))}
-                </SelectContent>
-              </Select>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
 
             {paramsError && (

--- a/lib/encounter-generator.ts
+++ b/lib/encounter-generator.ts
@@ -73,17 +73,17 @@ export const COMPOSITION_CONFIG: Record<EncounterComposition, {
 
 const TOLERANCE_BANDS = [0.15, 0.30, 0.50]
 
-export function filterBestiaryByCreatureType(bestiary: DbMonster[], typeFilter: string): DbMonster[] {
+export function filterBestiaryByCreatureType(bestiary: DbMonster[], typeFilters: string[]): DbMonster[] {
   const pool = bestiary.filter(m => m.challenge_rating_xp != null && m.challenge_rating_xp > 0)
-  const q = typeFilter.trim().toLowerCase()
-  if (!q) return pool
-  return pool.filter(m => m.creature_type?.toLowerCase() === q)
+  if (typeFilters.length === 0) return pool
+  const set = new Set(typeFilters.map(t => t.toLowerCase()))
+  return pool.filter(m => m.creature_type != null && set.has(m.creature_type.toLowerCase()))
 }
 
-export function filterBestiaryByHabitat(bestiary: DbMonster[], habitatFilter: string): DbMonster[] {
-  const q = habitatFilter.trim().toLowerCase()
-  if (!q) return bestiary
-  return bestiary.filter(m => m.habitat?.some(h => h.toLowerCase() === q))
+export function filterBestiaryByHabitat(bestiary: DbMonster[], habitatFilters: string[]): DbMonster[] {
+  if (habitatFilters.length === 0) return bestiary
+  const set = new Set(habitatFilters.map(h => h.toLowerCase()))
+  return bestiary.filter(m => m.habitat?.some(h => set.has(h.toLowerCase())))
 }
 
 function pickMonsterNear(target: number, candidates: DbMonster[]): { monster: DbMonster; withinTolerance: boolean } {


### PR DESCRIPTION
## Summary
- Both the "Type de créature" and "Habitat" filters in the encounter generator dialog now support selecting **several** values at once, via a checkbox-style dropdown (`DropdownMenuCheckboxItem`) instead of a single-value `Select`.
- Semantics: within each dimension it's an OR (matches any selected type / any selected habitat); across dimensions it's an AND (type-match AND habitat-match). Selecting several just broadens the candidate pool — no forced diversity/round-robin across the selection, natural variety from the larger pool is enough (confirmed with the user before building).

## Test plan
- [x] `tsc --noEmit` shows zero new errors from this change
- [x] Functional tests against the live bestiary: empty filter = unchanged behavior, single-value array = identical to old single-select, multi-value OR correctly includes all selected categories, combined type+habitat correctly ANDs the two OR-groups (including a legitimate empty-result case that correctly triggers the existing "no monster matches" error)
- [x] End-to-end `generateEncounter` from a multi-type pool produces a genuine natural mix
- [ ] Manual click-through in a browser (not verified visually this session — browser tooling in this environment isn't network-reachable to the local dev container)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
