### PR TITLE
fix: Sync MJ roster and header name with the selected campaign

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,6 +12,7 @@ import { toast } from "sonner"
 import { useSocketContext } from "@/lib/socket-context"
 import type { Character, Monster, CombatParticipant, DbMonster, CharacterInventory, ActiveBuff, Note, JournalCampaign } from "@/lib/types"
 import type { GeneratedEncounterRow } from "@/lib/encounter-generator"
+import { characterMatchesCampaign } from "@/lib/campaign-match"
 import { DEFAULT_INVENTORY } from "@/lib/types"
 import type { AmbientEffect } from "@/components/ambient-effects"
 import type { HistoryEntry } from "@/components/combat-history-panel"
@@ -604,6 +605,7 @@ function CombatTrackerContent() {
               max_spell_slots: Record<number, number> | null
               is_warlock: boolean
               saving_throw_proficiencies: string[]
+              campaigns: string[]
             }) => {
               // Load persisted data from database in parallel
               const [inventory, persistedStatus] = await Promise.all([
@@ -639,6 +641,7 @@ function CombatTrackerContent() {
                 maxSpellSlots: c.max_spell_slots ?? undefined,
                 spellSlots: persistedStatus.spellSlots ?? c.max_spell_slots ?? undefined,
                 isWarlock: c.is_warlock,
+                campaigns: c.campaigns,
               }
             })
           )
@@ -891,6 +894,7 @@ function CombatTrackerContent() {
           maxSpellSlots: campaignChar?.maxSpellSlots,
           spellSlots: char.spellSlots ?? campaignChar?.spellSlots ?? campaignChar?.maxSpellSlots,
           isWarlock: campaignChar?.isWarlock,
+          campaigns: campaignChar?.campaigns,
         })
       })
     })
@@ -955,6 +959,17 @@ function CombatTrackerContent() {
       return a.name.localeCompare(b.name)
     })
   }, [socketState.connectedPlayers, allCampaignCharacters, socketState.combatState.participants, playerInitiatives, players])
+
+  // Name of the campaign currently selected (login screen picker) — used for
+  // the header badge and to filter the MJ's roster below
+  const activeCampaignName = journalCampaigns.find((c) => c.id === journalCampaignId)?.name ?? campaignName
+
+  // MJ roster ("Groupe" panel) filtered to the selected campaign, so a DM
+  // running a one-shot doesn't see the main campaign's characters and vice versa
+  const campaignPlayers = useMemo(() => {
+    if (!activeCampaignName) return displayPlayers
+    return displayPlayers.filter((p) => characterMatchesCampaign(p, activeCampaignName))
+  }, [displayPlayers, activeCampaignName])
 
   // Memoize connected player IDs to avoid infinite loops
   const connectedPlayerIds = useMemo(() => {
@@ -2971,7 +2986,7 @@ function CombatTrackerContent() {
 
       <Header
         mode={mode}
-        campaignName={campaignName}
+        campaignName={activeCampaignName}
         selectedCharacterName={selectedCharacterNames}
         onSettingsClick={() => setShowSettings(true)}
         onLogout={() => {
@@ -3017,7 +3032,7 @@ function CombatTrackerContent() {
               {activeTab === "players" && mode === "mj" && (
                 <PlayerPanel
                   key={`players-${socketState.connectedPlayers.length}`}
-                  players={displayPlayers}
+                  players={campaignPlayers}
                   onUpdateHp={updatePlayerHp}
                   onUpdateInitiative={updatePlayerInitiative}
                   onUpdateConditions={updatePlayerConditions}
@@ -3150,7 +3165,7 @@ function CombatTrackerContent() {
                 {mode === "mj" && (
                   <div className="col-span-3 h-full overflow-auto">
                     <PlayerPanel
-                      players={displayPlayers}
+                      players={campaignPlayers}
                       onUpdateHp={updatePlayerHp}
                       onUpdateInitiative={updatePlayerInitiative}
                       onUpdateConditions={updatePlayerConditions}
@@ -3304,7 +3319,7 @@ function CombatTrackerContent() {
                 {mode === "mj" && (
                   <div className="col-span-3 h-full overflow-auto">
                     <PlayerPanel
-                      players={displayPlayers}
+                      players={campaignPlayers}
                       onUpdateHp={updatePlayerHp}
                       onUpdateInitiative={updatePlayerInitiative}
                       onUpdateConditions={updatePlayerConditions}

--- a/components/user-selection-screen.tsx
+++ b/components/user-selection-screen.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/ui/select"
 import { cn } from "@/lib/utils"
 import type { JournalCampaign } from "@/lib/types"
+import { characterMatchesCampaign } from "@/lib/campaign-match"
 
 interface CharacterInfo {
   id: string | number
@@ -37,27 +38,6 @@ interface CharacterInfo {
   max_spell_slots?: Record<number, number> | null
   is_warlock?: boolean
   campaigns?: string[]
-}
-
-// Notion's "Campagne" tags and the app's campaign names are entered separately
-// and can drift (e.g. "One-shot" vs "One-Shot", or a name with an extra suffix),
-// so match loosely rather than requiring an exact string.
-function normalize(value: string): string {
-  return value.trim().toLowerCase()
-}
-
-function characterMatchesCampaign(character: CharacterInfo, campaignName: string): boolean {
-  const tags = character.campaigns
-  if (!tags || tags.length === 0) return true // untagged characters show in every campaign
-  const normalizedCampaign = normalize(campaignName)
-  return tags.some((tag) => {
-    const normalizedTag = normalize(tag)
-    return (
-      normalizedTag === normalizedCampaign ||
-      normalizedCampaign.includes(normalizedTag) ||
-      normalizedTag.includes(normalizedCampaign)
-    )
-  })
 }
 
 interface UserSelectionScreenProps {

--- a/lib/campaign-match.ts
+++ b/lib/campaign-match.ts
@@ -1,0 +1,26 @@
+// Notion's "Campagne" tags and the app's campaign names are entered
+// separately (one in Notion, one in Settings) and can drift — e.g. a Notion
+// tag "One-shot" vs a campaign named "One-Shot", or a tag missing a suffix
+// the campaign name has. Match loosely instead of requiring an exact string.
+
+function normalizeCampaignValue(value: string): string {
+  return value.trim().toLowerCase()
+}
+
+export function characterMatchesCampaign(
+  character: { campaigns?: string[] },
+  campaignName: string
+): boolean {
+  const tags = character.campaigns
+  if (!tags || tags.length === 0) return true // untagged characters show in every campaign
+
+  const normalizedCampaign = normalizeCampaignValue(campaignName)
+  return tags.some((tag) => {
+    const normalizedTag = normalizeCampaignValue(tag)
+    return (
+      normalizedTag === normalizedCampaign ||
+      normalizedCampaign.includes(normalizedTag) ||
+      normalizedTag.includes(normalizedCampaign)
+    )
+  })
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -144,6 +144,7 @@ export interface Character {
   spellSlots?: Record<number, number>     // Current available slots {1: 4, 2: 3, ...}
   maxSpellSlots?: Record<number, number>  // Max slots from Notion
   isWarlock?: boolean                      // Warlocks recover slots on short rest
+  campaigns?: string[]                     // Campaign tags from Notion's "Campagne" multi-select
 }
 
 export interface Monster {


### PR DESCRIPTION
## Summary
- The DM's "Groupe" roster panel listed every character regardless of the campaign picked at login — now filtered to the selected campaign using the same fuzzy Notion-tag matching as the login screen (extracted to `lib/campaign-match.ts` to avoid duplicating it).
- The header campaign-name badge always showed the main campaign's name instead of whichever campaign is currently selected.

## Test plan
- [ ] Log in as MJ with a campaign that has only some characters tagged for it in Notion, confirm the "Groupe" panel only shows those (untagged characters still show everywhere).
- [ ] Confirm header badge shows the selected campaign's name, and updates correctly per campaign.
- [ ] Confirm switching campaigns via the login picker doesn't affect combat/HP behavior for already-connected players.

https://claude.ai/code/session_01Da8ahiZ4Sqv9YZpXU28UiC
