### PR TITLE
fix: Replace crypto.randomUUID() with a plain id in encounter generator

### DIFF
--- a/lib/encounter-generator.ts
+++ b/lib/encounter-generator.ts
@@ -73,6 +73,13 @@ export const COMPOSITION_CONFIG: Record<EncounterComposition, {
 
 const TOLERANCE_BANDS = [0.15, 0.30, 0.50]
 
+// crypto.randomUUID() is a secure-context-only API (HTTPS or localhost) and
+// throws on a plain-HTTP LAN deployment, so use a plain id instead — this is
+// just a React key, not a security-sensitive identifier.
+function generateRowId(): string {
+  return `row-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
+}
+
 export function filterBestiaryByCreatureType(bestiary: DbMonster[], typeFilters: string[]): DbMonster[] {
   const pool = bestiary.filter(m => m.challenge_rating_xp != null && m.challenge_rating_xp > 0)
   if (typeFilters.length === 0) return pool
@@ -118,7 +125,7 @@ export function generateEncounter(params: {
   const perMonsterTarget = params.targetXp / params.monsterCount
   const rows: GeneratedEncounterRow[] = Array.from({ length: params.monsterCount }, () => {
     const { monster, withinTolerance } = pickMonsterNear(perMonsterTarget, params.candidates)
-    return { id: crypto.randomUUID(), monster, targetShareXp: perMonsterTarget, withinTolerance }
+    return { id: generateRowId(), monster, targetShareXp: perMonsterTarget, withinTolerance }
   })
 
   const totalXp = rows.reduce((sum, row) => sum + (row.monster.challenge_rating_xp || 0), 0)


### PR DESCRIPTION
## Summary
- `crypto.randomUUID()` is a secure-context-only Web API (HTTPS or `localhost`). The Synology deployment is plain HTTP on a LAN IP (`http://192.168.1.2:3000`), so clicking "Générer" in the encounter generator threw immediately and silently — no error toast, nothing in the UI, only visible in the browser console.
- Row ids are just React keys, not security-sensitive, so swapped in a timestamp+random-string id that works in any context.

## Root cause
Confirmed by reproducing the reasoning against the actual prod endpoints (bestiary data is clean, 75 monsters, no nulls) and finding the one `crypto.randomUUID()` call in `lib/encounter-generator.ts` — the only Web-Crypto-only API used in a code path with no try/catch around it.

## Test plan
- [ ] On the Synology deployment (HTTP), open Préparation du Combat → Générer une rencontre, set any params, click "Générer" — should move to the preview step with monster rows, not silently do nothing.

https://claude.ai/code/session_01Da8ahiZ4Sqv9YZpXU28UiC
