### PR TITLE
Add Berserker Titles — barbarian daily achievement tracker

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -228,6 +228,13 @@ hooks/                    # Custom React hooks
 
 ## Recent Work
 
+- **2026-08-19**: Berserker Titles — barbarian daily achievements (`feature/barbarian-titles` branch)
+  - Homebrew mechanic scoped to one character (Taylan, `BERSERKER_TITLES_CHARACTER_ID` in `lib/berserker-titles.ts`): 8 hardcoded titles, each a daily challenge condition + a boost description. All reset on long rest (no per-combat variant — simplified after an earlier version distinguished reset cadences).
+  - No new DB/API layer: achievement state is derived entirely from the existing buff system — marking a title achieved adds a custom `ActiveBuff` (`buffId: berserker-<title-id>`) to the character via the existing `onUpdateBuffs`/`updatePlayerBuffs` flow, so it's already persisted (`character_hp.buffs`), synced over sockets, and visible as a normal buff badge everywhere.
+  - In `SpellbookPanel` (the "Sorts" tab), this character is special-cased to render `BerserkerTitlesCard` instead of the spell-slot UI, in place of a spellbook that a Barbarian wouldn't have. Manual toggle only — the app doesn't track kills/damage, so there's no auto-detection.
+  - Reset wiring: `app/page.tsx`'s `handleLongRest` strips all `berserker-*` buffs (`ALL_BERSERKER_BUFF_IDS`) on long rest.
+  - Files: `lib/berserker-titles.ts` (new), `components/berserker-titles-card.tsx` (new), `components/spellbook-panel.tsx`, `app/page.tsx`
+
 - **2026-08-19**: Multi-campaign Notion journal routing (`feature/campaign-journal-select` branch)
   - The `campaigns` table already partitions characters/combat/notes/etc. by `campaign_id`, but the app only ever used `DEFAULT_CAMPAIGN_ID = 1` and never rendered `campaign-selector.tsx` — it was dead code. Rather than turning on full multi-tenancy, this keeps a single shared roster/combat/bestiary and repurposes `campaigns` purely as a list of (name, Notion journal database ID) pairs, so the DM can pick which Notion "Journal de Campagne" database session notes sync to.
   - `campaigns.notion_journal_database_id` column added. `getCampaigns()` auto-bootstraps a default row (from `NOTION_JOURNAL_DATABASE_ID` env var) if the table is empty, so first-run/legacy installs keep working.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,6 +13,7 @@ import { useSocketContext } from "@/lib/socket-context"
 import type { Character, Monster, CombatParticipant, DbMonster, CharacterInventory, ActiveBuff, Note, JournalCampaign } from "@/lib/types"
 import type { GeneratedEncounterRow } from "@/lib/encounter-generator"
 import { characterMatchesCampaign } from "@/lib/campaign-match"
+import { ALL_BERSERKER_BUFF_IDS } from "@/lib/berserker-titles"
 import { DEFAULT_INVENTORY } from "@/lib/types"
 import type { AmbientEffect } from "@/components/ambient-effects"
 import type { HistoryEntry } from "@/components/combat-history-panel"
@@ -1882,31 +1883,43 @@ function CombatTrackerContent() {
     const maxSlots = player.maxSpellSlots || {}
     const newSlots = { ...maxSlots }
 
+    // Berserker titles reset on long rest, same as any other daily resource
+    const currentBuffs = player.buffs || []
+    const newBuffs = currentBuffs.filter((b) => !ALL_BERSERKER_BUFF_IDS.includes(b.buffId))
+    const buffsChanged = newBuffs.length !== currentBuffs.length
+
     // Update local state
     setPlayers((prev) => prev.map((p) =>
-      p.id === characterId ? { ...p, spellSlots: newSlots } : p
+      p.id === characterId ? { ...p, spellSlots: newSlots, buffs: newBuffs } : p
     ))
 
     if (combatActive) {
       setCombatParticipants((prev) =>
-        prev.map((p) => (p.id === characterId ? { ...p, spellSlots: newSlots } : p))
+        prev.map((p) => (p.id === characterId ? { ...p, spellSlots: newSlots, buffs: newBuffs } : p))
       )
     }
 
-    // Emit socket event
+    // Emit socket events
     emitSpellSlotChange({
       participantId: characterId,
       participantType: 'player',
       spellSlots: newSlots,
       source: mode === 'mj' ? 'dm' : 'player',
     })
+    if (buffsChanged) {
+      emitBuffChange({
+        participantId: characterId,
+        participantType: 'player',
+        buffs: newBuffs,
+      })
+    }
 
     // Persist to database
     try {
       await fetch(`/api/characters/${characterId}/hp`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ spellSlots: newSlots }),
+        body: JSON.stringify({ spellSlots: newSlots, buffs: newBuffs }),
       })
       console.log('[SpellSlots] Long rest - restored all slots:', characterId)
       toast.success(`${player.name} récupère ses emplacements (repos long)`)
@@ -3075,6 +3088,7 @@ function CombatTrackerContent() {
                   onSpellSlotChange={updatePlayerSpellSlot}
                   onShortRest={handleShortRest}
                   onLongRest={handleLongRest}
+                  onUpdateBuffs={updatePlayerBuffs}
                 />
               )}
               {activeTab === "combat" && (
@@ -3216,6 +3230,7 @@ function CombatTrackerContent() {
                       onSpellSlotChange={updatePlayerSpellSlot}
                       onShortRest={handleShortRest}
                       onLongRest={handleLongRest}
+                      onUpdateBuffs={updatePlayerBuffs}
                     />
                   </div>
                 )}
@@ -3295,6 +3310,7 @@ function CombatTrackerContent() {
                   onSpellSlotChange={updatePlayerSpellSlot}
                   onShortRest={handleShortRest}
                   onLongRest={handleLongRest}
+                  onUpdateBuffs={updatePlayerBuffs}
                 />
               </div>
               <div className="col-span-2 flex items-center justify-center">

--- a/components/berserker-titles-card.tsx
+++ b/components/berserker-titles-card.tsx
@@ -1,0 +1,102 @@
+"use client"
+
+import { Check, Sun } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import { BERSERKER_TITLES, berserkerBuffId } from "@/lib/berserker-titles"
+import type { Character, ActiveBuff } from "@/lib/types"
+
+interface BerserkerTitlesCardProps {
+  character: Character
+  onUpdateBuffs: (characterId: string, buffs: ActiveBuff[]) => void
+  onLongRest: (characterId: string) => void
+}
+
+export function BerserkerTitlesCard({ character, onUpdateBuffs, onLongRest }: BerserkerTitlesCardProps) {
+  const buffs = character.buffs || []
+
+  const toggleTitle = (titleId: string, name: string, boost: string) => {
+    const buffId = berserkerBuffId(titleId)
+    const isAchieved = buffs.some((b) => b.buffId === buffId)
+
+    const newBuffs: ActiveBuff[] = isAchieved
+      ? buffs.filter((b) => b.buffId !== buffId)
+      : [
+          ...buffs,
+          {
+            buffId,
+            remainingTurns: null,
+            customName: name,
+            customEffect: boost,
+            customType: "buff",
+            customColor: "red",
+          },
+        ]
+
+    onUpdateBuffs(character.id, newBuffs)
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        {BERSERKER_TITLES.map((title, index) => {
+          const isAchieved = buffs.some((b) => b.buffId === berserkerBuffId(title.id))
+          return (
+            <button
+              key={title.id}
+              type="button"
+              onClick={() => toggleTitle(title.id, title.name, title.boost)}
+              className={cn(
+                "w-full text-left p-3 rounded-lg border transition-all",
+                isAchieved
+                  ? "bg-red-500/10 border-red-500/50"
+                  : "bg-secondary/30 border-border/50 hover:border-red-500/30"
+              )}
+            >
+              <div className="flex items-start gap-2">
+                <div
+                  className={cn(
+                    "w-5 h-5 mt-0.5 rounded border-2 flex items-center justify-center shrink-0",
+                    isAchieved ? "border-red-500 bg-red-500" : "border-muted-foreground"
+                  )}
+                >
+                  {isAchieved && <Check className="w-3 h-3 text-background" />}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <span
+                    className={cn(
+                      "text-sm font-semibold",
+                      isAchieved ? "text-red-400" : "text-foreground"
+                    )}
+                  >
+                    #{index + 1} {title.name}
+                  </span>
+                  <p className="text-xs text-muted-foreground mt-0.5">{title.condition}</p>
+                  <p
+                    className={cn(
+                      "text-xs mt-1",
+                      isAchieved ? "text-red-300" : "text-muted-foreground/70"
+                    )}
+                  >
+                    {title.boost}
+                  </p>
+                </div>
+              </div>
+            </button>
+          )
+        })}
+      </div>
+
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="w-full text-gold border-gold/30 hover:bg-gold/10 hover:border-gold/50"
+        onClick={() => onLongRest(character.id)}
+      >
+        <Sun className="w-4 h-4 mr-2" />
+        Repos long
+      </Button>
+    </div>
+  )
+}

--- a/components/spellbook-panel.tsx
+++ b/components/spellbook-panel.tsx
@@ -32,7 +32,9 @@ import { cn } from "@/lib/utils"
 import { getSocket } from "@/lib/socket"
 import { SpellPickerDialog } from "./spell-picker-dialog"
 import { SpellDetail } from "./spell-detail"
-import type { Character, PreparedSpell, CatalogSpell } from "@/lib/types"
+import { BerserkerTitlesCard } from "./berserker-titles-card"
+import { BERSERKER_TITLES_CHARACTER_ID } from "@/lib/berserker-titles"
+import type { Character, PreparedSpell, CatalogSpell, ActiveBuff } from "@/lib/types"
 
 // D&D spell level names in French
 const SPELL_LEVELS = [
@@ -57,6 +59,7 @@ interface SpellbookPanelProps {
     spell: CatalogSpell,
     slotLevel: number
   ) => void
+  onUpdateBuffs?: (characterId: string, buffs: ActiveBuff[]) => void
   isDm?: boolean
   campaignId?: number
 }
@@ -67,6 +70,7 @@ export function SpellbookPanel({
   onShortRest,
   onLongRest,
   onCastSpell,
+  onUpdateBuffs,
   isDm = false,
   campaignId = 1,
 }: SpellbookPanelProps) {
@@ -87,6 +91,13 @@ export function SpellbookPanel({
     const maxSlots = char.maxSpellSlots || {}
     return Object.keys(maxSlots).length > 0
   })
+
+  // The Berserker titles tracker takes over this tab for its one character,
+  // in place of a (non-existent, for this class) spellbook
+  const berserkerCharacter = characters.find((char) => char.id === BERSERKER_TITLES_CHARACTER_ID)
+  const visibleCharacters = berserkerCharacter
+    ? [berserkerCharacter, ...spellcasters.filter((c) => c.id !== BERSERKER_TITLES_CHARACTER_ID)]
+    : spellcasters
 
   // Load prepared spells for all spellcasters
   const loadPreparedSpells = useCallback(
@@ -486,7 +497,7 @@ export function SpellbookPanel({
         </CardHeader>
         <CardContent className="flex-1 overflow-hidden p-0">
           <ScrollArea className="h-full px-4 md:px-6 pb-6">
-            {spellcasters.length === 0 ? (
+            {visibleCharacters.length === 0 ? (
               <div className="text-center text-muted-foreground py-8">
                 <Sparkles className="w-12 h-12 mx-auto mb-3 opacity-30" />
                 <p className="text-sm">Aucun lanceur de sorts</p>
@@ -496,22 +507,36 @@ export function SpellbookPanel({
               </div>
             ) : (
               <div className="space-y-4">
-                {spellcasters.map((character) => (
-                  <div
-                    key={character.id}
-                    className="bg-secondary/30 rounded-lg border border-border/50 p-4"
-                  >
-                    <div className="flex items-center justify-between gap-2 mb-3">
-                      <h3 className="font-bold text-foreground flex-1 min-w-0 truncate">
-                        {character.name}
-                      </h3>
-                      <span className="text-xs text-muted-foreground shrink-0">
-                        {character.class} Niv. {character.level}
-                      </span>
+                {visibleCharacters.map((character) => {
+                  const isBerserker = character.id === BERSERKER_TITLES_CHARACTER_ID
+                  return (
+                    <div
+                      key={character.id}
+                      className="bg-secondary/30 rounded-lg border border-border/50 p-4"
+                    >
+                      <div className="flex items-center justify-between gap-2 mb-3">
+                        <h3 className={cn(
+                          "font-bold flex-1 min-w-0 truncate",
+                          isBerserker ? "text-red-400" : "text-foreground"
+                        )}>
+                          {isBerserker ? "🏆 Titres du Berserker" : character.name}
+                        </h3>
+                        <span className="text-xs text-muted-foreground shrink-0">
+                          {character.class} Niv. {character.level}
+                        </span>
+                      </div>
+                      {isBerserker && onUpdateBuffs ? (
+                        <BerserkerTitlesCard
+                          character={character}
+                          onUpdateBuffs={onUpdateBuffs}
+                          onLongRest={onLongRest}
+                        />
+                      ) : (
+                        renderCharacterSpells(character)
+                      )}
                     </div>
-                    {renderCharacterSpells(character)}
-                  </div>
-                ))}
+                  )
+                })}
               </div>
             )}
           </ScrollArea>

--- a/lib/berserker-titles.ts
+++ b/lib/berserker-titles.ts
@@ -1,0 +1,76 @@
+// Homebrew barbarian achievement system: "Les Titres du Berserker"
+//
+// Each title is a daily challenge the player marks off in play. Achieving one
+// applies a matching buff through the existing buff system (see ActiveBuff in
+// lib/types.ts) — achievement state is just derived from whether the
+// character currently carries the matching `berserker-<id>` buff, so no
+// separate persistence layer is needed beyond the buffs already stored on
+// the character. All titles reset on long rest.
+
+export interface BerserkerTitle {
+  id: string
+  name: string
+  condition: string
+  boost: string
+}
+
+// Taylan — this tracker is scoped to this one character
+export const BERSERKER_TITLES_CHARACTER_ID = "3c1300de-717f-805b-b373-fec31030f88a"
+
+export const BERSERKER_TITLES: BerserkerTitle[] = [
+  {
+    id: "premier-sang",
+    name: "Premier Sang",
+    condition: "Premier kill de la journée",
+    boost: "+1 aux dégâts jusqu'au prochain long repos",
+  },
+  {
+    id: "la-tempete",
+    name: "La Tempête",
+    condition: "3 kills dans le même combat",
+    boost: "Rage gratuite supplémentaire",
+  },
+  {
+    id: "sans-pitie",
+    name: "Sans Pitié",
+    condition: "10 kills dans la même journée",
+    boost: "Avantage sur tous les jets d'intimidation jusqu'au prochain long repos",
+  },
+  {
+    id: "la-muraille",
+    name: "La Muraille",
+    condition: "Utiliser sa réaction pour s'interposer à 1,5m d'un allié",
+    boost: "+5 PV temporaires jusqu'au prochain long repos",
+  },
+  {
+    id: "david-vs-goliath",
+    name: "David vs Goliath",
+    condition: "Tuer un ennemi physiquement plus grand",
+    boost: "Avantage sur les jets d'attaque contre des ennemis plus grands jusqu'au prochain long repos",
+  },
+  {
+    id: "la-terreur",
+    name: "La Terreur",
+    condition: "Faire fuir des ennemis sans porter un seul coup",
+    boost: "Désavantage aux jets de résistance d'intimidation ennemis jusqu'au prochain long repos",
+  },
+  {
+    id: "intouchable",
+    name: "Intouchable",
+    condition: "Terminer un combat sans prendre de dégâts",
+    boost: "+2 à l'initiative jusqu'au prochain long repos",
+  },
+  {
+    id: "la-legende",
+    name: "La Légende",
+    condition: "Débloquer 5 succès dans la même journée",
+    boost: "1 point d'inspiration gratuit",
+  },
+]
+
+export function berserkerBuffId(titleId: string): string {
+  return `berserker-${titleId}`
+}
+
+// All title buffs — cleared on long rest so the next day starts fresh
+export const ALL_BERSERKER_BUFF_IDS = BERSERKER_TITLES.map((t) => berserkerBuffId(t.id))


### PR DESCRIPTION
## Summary

Implements a homebrew barbarian achievement system ("Les Titres du Berserker") scoped to a single character (Taylan). Players can manually mark off 8 daily challenges, each granting a buff that persists until the next long rest. All titles reset automatically on long rest.

## Key Changes

- **New component `BerserkerTitlesCard`** (`components/berserker-titles-card.tsx`)
  - Renders 8 hardcoded titles with toggle UI (checkbox-style buttons)
  - Each title shows condition, boost description, and achievement state
  - Includes "Repos long" button to trigger long rest
  - Toggles add/remove custom `ActiveBuff` entries via `onUpdateBuffs` callback

- **New module `lib/berserker-titles.ts`**
  - Defines `BerserkerTitle` interface and `BERSERKER_TITLES` array (8 titles in French)
  - Exports `BERSERKER_TITLES_CHARACTER_ID` constant (Taylan's character ID)
  - Helper function `berserkerBuffId()` to generate buff IDs (`berserker-<title-id>`)
  - Exports `ALL_BERSERKER_BUFF_IDS` for reset logic

- **Modified `SpellbookPanel`** (`components/spellbook-panel.tsx`)
  - Added `onUpdateBuffs` prop to accept buff update callbacks
  - Special-cases Taylan's character: renders `BerserkerTitlesCard` instead of spell slots
  - Displays "🏆 Titres du Berserker" header in red for the Berserker character
  - Filters visible characters to include Berserker character alongside spellcasters

- **Modified `app/page.tsx`** (main combat tracker)
  - Updated `handleLongRest()` to strip all `berserker-*` buffs on long rest (via `ALL_BERSERKER_BUFF_IDS`)
  - Passes `onUpdateBuffs={updatePlayerBuffs}` to all `SpellbookPanel` instances
  - Emits socket buff-change events when titles are reset
  - Persists buff changes to database on long rest

## Implementation Details

- **No new DB/API layer**: Achievement state is derived entirely from the existing `ActiveBuff` system. Marking a title achieved adds a custom buff (`buffId: berserker-<title-id>`, `customType: "buff"`, `customColor: "red"`) to the character, which is persisted via the existing character HP endpoint and synced over sockets.
- **Manual toggle only**: The app does not auto-detect kills or damage; players manually mark titles as achieved.
- **Reset cadence**: All titles reset on long rest (no per-combat variant). The reset is wired into the existing `handleLongRest` flow and emits socket events to keep all clients in sync.
- **UI placement**: Titles appear in the "Sorts" (Spellbook) tab, replacing the spell-slot UI for this character (appropriate since a Barbarian has no spellbook).

## Testing Notes

- Verify toggle UI adds/removes buff badges on the character sheet
- Confirm long rest clears all Berserker title buffs
- Check socket sync: title toggles and resets should propagate to other connected clients
- Verify database persistence: refresh page and confirm buff state is restored

https://claude.ai/code/session_01Da8ahiZ4Sqv9YZpXU28UiC