### PR TITLE
Bestiary filters + settings sidebar redesign

### DIFF
--- a/app/monsters/page.tsx
+++ b/app/monsters/page.tsx
@@ -1,21 +1,37 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useMemo } from "react"
 import Link from "next/link"
-import { Search, Skull, ChevronLeft, Heart, Shield, Zap } from "lucide-react"
+import { Search, Skull, ChevronLeft, Heart, Shield, Zap, ChevronDown, X } from "lucide-react"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent } from "@/components/ui/card"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuCheckboxItem } from "@/components/ui/dropdown-menu"
 import { MonsterDetail } from "@/components/monster-detail"
 import { cn } from "@/lib/utils"
+import { xpToChallengeRating } from "@/lib/challenge-rating"
 import type { DbMonster } from "@/lib/types"
+
+function toggleInArray<T>(values: T[], value: T): T[] {
+  return values.includes(value) ? values.filter((v) => v !== value) : [...values, value]
+}
+
+function summarizeSelection(count: number, allLabel: string, unit: string): string {
+  if (count === 0) return allLabel
+  if (count <= 2) return `${count} ${unit}`
+  return `${count} ${unit} sélectionnés`
+}
 
 export default function MonstersPage() {
   const [monsters, setMonsters] = useState<DbMonster[]>([])
   const [filteredMonsters, setFilteredMonsters] = useState<DbMonster[]>([])
   const [searchQuery, setSearchQuery] = useState("")
+  const [creatureTypeFilters, setCreatureTypeFilters] = useState<string[]>([])
+  const [habitatFilters, setHabitatFilters] = useState<string[]>([])
+  const [crFilters, setCrFilters] = useState<number[]>([])
+  const [habitatOptions, setHabitatOptions] = useState<string[]>([])
   const [selectedMonster, setSelectedMonster] = useState<DbMonster | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -43,21 +59,64 @@ export default function MonstersPage() {
     fetchMonsters()
   }, [])
 
-  // Filter monsters based on search query
   useEffect(() => {
-    if (!searchQuery.trim()) {
-      setFilteredMonsters(monsters)
-    } else {
-      const query = searchQuery.toLowerCase()
-      setFilteredMonsters(
-        monsters.filter(
-          (m) =>
-            m.name.toLowerCase().includes(query) ||
-            m.creature_type?.toLowerCase().includes(query)
-        )
-      )
+    async function fetchHabitats() {
+      try {
+        const response = await fetch("/api/monsters/habitats")
+        if (!response.ok) throw new Error("Failed to fetch habitats")
+        setHabitatOptions(await response.json())
+      } catch {
+        // Non-critical: habitat filter simply stays empty
+      }
     }
-  }, [searchQuery, monsters])
+    fetchHabitats()
+  }, [])
+
+  const creatureTypes = useMemo(
+    () => [...new Set(monsters.map((m) => m.creature_type).filter((t): t is string => !!t))].sort(),
+    [monsters]
+  )
+
+  const crOptions = useMemo(() => {
+    const xps = [...new Set(monsters.map((m) => m.challenge_rating_xp).filter((xp): xp is number => xp != null))]
+    return xps.sort((a, b) => a - b).map((xp) => ({ xp, label: xpToChallengeRating(xp) }))
+  }, [monsters])
+
+  const hasActiveFilters =
+    searchQuery.trim() !== "" || creatureTypeFilters.length > 0 || habitatFilters.length > 0 || crFilters.length > 0
+
+  const resetFilters = () => {
+    setSearchQuery("")
+    setCreatureTypeFilters([])
+    setHabitatFilters([])
+    setCrFilters([])
+  }
+
+  // Filter monsters based on search query and selected filters
+  useEffect(() => {
+    const query = searchQuery.trim().toLowerCase()
+    const typeSet = new Set(creatureTypeFilters.map((t) => t.toLowerCase()))
+    const habitatSet = new Set(habitatFilters.map((h) => h.toLowerCase()))
+    const crSet = new Set(crFilters)
+
+    setFilteredMonsters(
+      monsters.filter((m) => {
+        if (query && !m.name.toLowerCase().includes(query) && !m.creature_type?.toLowerCase().includes(query)) {
+          return false
+        }
+        if (typeSet.size > 0 && !(m.creature_type && typeSet.has(m.creature_type.toLowerCase()))) {
+          return false
+        }
+        if (habitatSet.size > 0 && !m.habitat?.some((h) => habitatSet.has(h.toLowerCase()))) {
+          return false
+        }
+        if (crSet.size > 0 && !(m.challenge_rating_xp != null && crSet.has(m.challenge_rating_xp))) {
+          return false
+        }
+        return true
+      })
+    )
+  }, [searchQuery, creatureTypeFilters, habitatFilters, crFilters, monsters])
 
   if (loading) {
     return (
@@ -113,7 +172,7 @@ export default function MonstersPage() {
 
       <main className="container mx-auto p-4 animate-fade-in">
         {/* Search */}
-        <div className="max-w-md mx-auto mb-6">
+        <div className="max-w-md mx-auto mb-4">
           <div className="relative">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-muted-foreground" />
             <Input
@@ -123,6 +182,79 @@ export default function MonstersPage() {
               className="pl-10 bg-card text-lg min-h-[48px]"
             />
           </div>
+        </div>
+
+        {/* Filters */}
+        <div className="max-w-3xl mx-auto mb-6 flex flex-wrap items-center justify-center gap-2">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" className="min-h-[44px] font-normal justify-between gap-2">
+                {summarizeSelection(creatureTypeFilters.length, "Tous les types", "types")}
+                <ChevronDown className="h-4 w-4 opacity-50" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className="max-h-72 overflow-y-auto">
+              {creatureTypes.map((type) => (
+                <DropdownMenuCheckboxItem
+                  key={type}
+                  checked={creatureTypeFilters.includes(type)}
+                  onSelect={(e) => e.preventDefault()}
+                  onCheckedChange={() => setCreatureTypeFilters((prev) => toggleInArray(prev, type))}
+                >
+                  {type}
+                </DropdownMenuCheckboxItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" className="min-h-[44px] font-normal justify-between gap-2">
+                {summarizeSelection(habitatFilters.length, "Tous les habitats", "habitats")}
+                <ChevronDown className="h-4 w-4 opacity-50" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className="max-h-72 overflow-y-auto">
+              {habitatOptions.map((habitat) => (
+                <DropdownMenuCheckboxItem
+                  key={habitat}
+                  checked={habitatFilters.includes(habitat)}
+                  onSelect={(e) => e.preventDefault()}
+                  onCheckedChange={() => setHabitatFilters((prev) => toggleInArray(prev, habitat))}
+                >
+                  {habitat}
+                </DropdownMenuCheckboxItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" className="min-h-[44px] font-normal justify-between gap-2">
+                {summarizeSelection(crFilters.length, "Tous les FP", "FP")}
+                <ChevronDown className="h-4 w-4 opacity-50" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className="max-h-72 overflow-y-auto">
+              {crOptions.map(({ xp, label }) => (
+                <DropdownMenuCheckboxItem
+                  key={xp}
+                  checked={crFilters.includes(xp)}
+                  onSelect={(e) => e.preventDefault()}
+                  onCheckedChange={() => setCrFilters((prev) => toggleInArray(prev, xp))}
+                >
+                  FP {label}
+                </DropdownMenuCheckboxItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          {hasActiveFilters && (
+            <Button variant="ghost" size="sm" className="min-h-[44px] text-muted-foreground" onClick={resetFilters}>
+              <X className="w-4 h-4 mr-1" />
+              Réinitialiser
+            </Button>
+          )}
         </div>
 
         {/* Results count */}

--- a/components/settings-panel.tsx
+++ b/components/settings-panel.tsx
@@ -4,13 +4,22 @@ import { useState, useEffect } from "react"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Button } from "@/components/ui/button"
-import { Separator } from "@/components/ui/separator"
 import { toast } from "sonner"
-import { Save, Key, Loader2, RefreshCw, Plus, Trash2, ArrowLeft } from "lucide-react"
+import { Save, Key, Loader2, RefreshCw, Plus, Trash2, ArrowLeft, BookOpen, Info } from "lucide-react"
 import { NotionSyncButton } from "@/components/notion-sync-button"
 import { ItemSyncDialog } from "@/components/item-sync-dialog"
 import { SpellSyncDialog } from "@/components/spell-sync-dialog"
+import { cn } from "@/lib/utils"
 import type { JournalCampaign } from "@/lib/types"
+
+type SectionId = "campaigns" | "password" | "notion-sync" | "about"
+
+const SECTIONS: { id: SectionId; label: string; icon: typeof Key }[] = [
+  { id: "campaigns", label: "Campagnes", icon: BookOpen },
+  { id: "password", label: "Mot de passe MJ", icon: Key },
+  { id: "notion-sync", label: "Synchronisation Notion", icon: RefreshCw },
+  { id: "about", label: "À propos", icon: Info },
+]
 
 interface SettingsPanelProps {
   campaignId: number
@@ -27,6 +36,7 @@ export function SettingsPanel({
   onMonsterSyncComplete,
   onClose,
 }: SettingsPanelProps) {
+  const [activeSection, setActiveSection] = useState<SectionId>("campaigns")
   const [campaigns, setCampaigns] = useState<JournalCampaign[]>([])
   const [savingCampaignId, setSavingCampaignId] = useState<number | null>(null)
   const [deletingCampaignId, setDeletingCampaignId] = useState<number | null>(null)
@@ -195,7 +205,7 @@ export function SettingsPanel({
   return (
     <div className="fixed inset-0 z-50 bg-background flex flex-col">
       <div className="shrink-0 border-b border-border bg-card">
-        <div className="max-w-2xl mx-auto px-4 py-3 flex items-center gap-3">
+        <div className="px-4 py-3 flex items-center gap-3">
           <Button variant="ghost" size="icon" onClick={onClose} aria-label="Retour">
             <ArrowLeft className="w-5 h-5" />
           </Button>
@@ -208,13 +218,36 @@ export function SettingsPanel({
         </div>
       </div>
 
-      <div className="flex-1 overflow-y-auto">
-        <div className="max-w-2xl mx-auto px-4 py-6 space-y-6">
-          {/* Campaigns Section */}
+      <div className="flex-1 min-h-0 flex flex-col md:flex-row">
+        {/* Section navigation */}
+        <nav className="shrink-0 flex md:flex-col gap-1 overflow-x-auto md:overflow-y-auto border-b md:border-b-0 md:border-r border-border bg-card/50 p-2 md:w-60 md:p-3">
+          {SECTIONS.map((section) => {
+            const Icon = section.icon
+            const isActive = activeSection === section.id
+            return (
+              <button
+                key={section.id}
+                onClick={() => setActiveSection(section.id)}
+                className={cn(
+                  "flex min-h-[44px] shrink-0 items-center gap-2 whitespace-nowrap rounded-lg px-3 py-2.5 text-left text-sm font-medium transition-colors md:w-full md:shrink",
+                  isActive
+                    ? "bg-secondary text-foreground"
+                    : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground"
+                )}
+              >
+                <Icon className="w-4 h-4 shrink-0" />
+                {section.label}
+              </button>
+            )
+          })}
+        </nav>
+
+        {/* Section content */}
+        <div className="flex-1 overflow-y-auto">
+          <div className="max-w-2xl px-4 py-6 space-y-4">
+          {activeSection === "campaigns" && (
           <div className="space-y-3">
-            <h4 className="text-sm font-medium flex items-center gap-2">
-              Campagnes
-            </h4>
+            <h2 className="text-base font-semibold">Campagnes</h2>
             <p className="text-xs text-muted-foreground">
               Les personnages et le combat restent partagés. Seul le journal Notion où
               sont synchronisées vos notes de session change selon la campagne sélectionnée à la connexion.
@@ -292,15 +325,11 @@ export function SettingsPanel({
               </Button>
             </div>
           </div>
+          )}
 
-          <Separator />
-
-          {/* Password Section */}
+          {activeSection === "password" && (
           <div className="space-y-3">
-            <h4 className="text-sm font-medium flex items-center gap-2">
-              <Key className="w-4 h-4" />
-              Mot de passe MJ
-            </h4>
+            <h2 className="text-base font-semibold">Mot de passe MJ</h2>
             <div className="space-y-3">
               <div className="space-y-1">
                 <Label htmlFor="currentPassword">Mot de passe actuel</Label>
@@ -349,15 +378,11 @@ export function SettingsPanel({
               </Button>
             </div>
           </div>
+          )}
 
-          <Separator />
-
-          {/* Notion Sync Section */}
+          {activeSection === "notion-sync" && (
           <div className="space-y-3">
-            <h4 className="text-sm font-medium flex items-center gap-2">
-              <RefreshCw className="w-4 h-4" />
-              Synchronisation Notion
-            </h4>
+            <h2 className="text-base font-semibold">Synchronisation Notion</h2>
             <p className="text-xs text-muted-foreground">
               Synchronisez vos données depuis Notion (monstres, items et sorts).
             </p>
@@ -367,17 +392,18 @@ export function SettingsPanel({
               <SpellSyncDialog />
             </div>
           </div>
+          )}
 
-          <Separator />
-
-          {/* About Section */}
+          {activeSection === "about" && (
           <div>
-            <h4 className="text-sm font-medium text-muted-foreground mb-3">À propos</h4>
+            <h2 className="text-base font-semibold mb-3">À propos</h2>
             <p className="text-xs text-muted-foreground">
               Compagnon D&D v1.0
               <br />
               Application de suivi de combat en temps réel pour vos sessions de jeu de rôle.
             </p>
+          </div>
+          )}
           </div>
         </div>
       </div>

--- a/lib/challenge-rating.ts
+++ b/lib/challenge-rating.ts
@@ -1,0 +1,50 @@
+// Standard D&D 5e "XP by Challenge Rating" table for individual monsters
+// (identical in the 2014 and 2024 rulesets)
+export const CHALLENGE_RATING_TABLE: { cr: string; xp: number }[] = [
+  { cr: "0", xp: 10 },
+  { cr: "1/8", xp: 25 },
+  { cr: "1/4", xp: 50 },
+  { cr: "1/2", xp: 100 },
+  { cr: "1", xp: 200 },
+  { cr: "2", xp: 450 },
+  { cr: "3", xp: 700 },
+  { cr: "4", xp: 1100 },
+  { cr: "5", xp: 1800 },
+  { cr: "6", xp: 2300 },
+  { cr: "7", xp: 2900 },
+  { cr: "8", xp: 3900 },
+  { cr: "9", xp: 5000 },
+  { cr: "10", xp: 5900 },
+  { cr: "11", xp: 7200 },
+  { cr: "12", xp: 8400 },
+  { cr: "13", xp: 10000 },
+  { cr: "14", xp: 11500 },
+  { cr: "15", xp: 13000 },
+  { cr: "16", xp: 15000 },
+  { cr: "17", xp: 18000 },
+  { cr: "18", xp: 20000 },
+  { cr: "19", xp: 22000 },
+  { cr: "20", xp: 25000 },
+  { cr: "21", xp: 33000 },
+  { cr: "22", xp: 41000 },
+  { cr: "23", xp: 50000 },
+  { cr: "24", xp: 62000 },
+  { cr: "25", xp: 75000 },
+  { cr: "26", xp: 90000 },
+  { cr: "27", xp: 105000 },
+  { cr: "28", xp: 120000 },
+  { cr: "29", xp: 135000 },
+  { cr: "30", xp: 155000 },
+]
+
+const XP_TO_CR = new Map(CHALLENGE_RATING_TABLE.map(({ cr, xp }) => [xp, cr]))
+
+/**
+ * Maps a monster's raw XP value to its "FP" (Facteur de Puissance / Challenge
+ * Rating) label, e.g. 25 -> "1/8". Falls back to the raw XP for values not on
+ * the standard table (custom/homebrew monsters), and "?" when there is none.
+ */
+export function xpToChallengeRating(xp: number | null): string {
+  if (xp == null) return "?"
+  return XP_TO_CR.get(xp) ?? `${xp} XP`
+}


### PR DESCRIPTION
## Summary
- `/monsters`: added multi-select filters for creature type, habitat, and FP (challenge rating), combinable with the existing search box, so you can narrow e.g. "humanoïde + montagne + FP 1/8" in one view
- New `lib/challenge-rating.ts`: standard 5e XP→FP lookup table (no schema change needed, derived from the existing `challenge_rating_xp` field)
- Settings panel: replaced the single long scrolling page with a left-nav / content-pane layout (Campagnes, Mot de passe MJ, Synchronisation Notion, À propos), collapsing to a horizontal tab strip on narrow screens

## Test plan
- [ ] Open `/monsters`, combine type + habitat + FP filters and confirm the grid narrows correctly, and "Réinitialiser" clears everything
- [ ] Open Paramètres, click through each sidebar section and confirm content swaps without losing in-progress form state unexpectedly
- [ ] Verify campaign save/create/delete and MJ password change still work from the new layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)